### PR TITLE
feat/proof input preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,11 @@ server:
 # Start all nodes in background
 node:
 	@echo "Starting zk-mpc-nodes (id=0,1,2) in background..."
-	cd packages/zk-mpc-node && cargo run --release start --id 0 &
-	cd packages/zk-mpc-node && cargo run --release start --id 1 &
-	cd packages/zk-mpc-node && cargo run --release start --id 2 &
+	# Start nodes 1 and 2 in background and discard their output
+	cd packages/zk-mpc-node && cargo run --release start --id 1 > /dev/null 2>&1 &
+	cd packages/zk-mpc-node && cargo run --release start --id 2 > /dev/null 2>&1 &
+	# Start node 0 in foreground so its output is shown
+	cd packages/zk-mpc-node && cargo run --release start --id 0
 	@echo "All nodes started in background!"
 
 # Stop all running services

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ node:
 	cd packages/zk-mpc-node && cargo run --release start --id 2 > /dev/null 2>&1 &
 	# Start node 0 in foreground so its output is shown
 	cd packages/zk-mpc-node && cargo run --release start --id 0
-	@echo "All nodes started in background!"
+	@echo "Background nodes 1 and 2 started; node 0 has exited."
 
 # Stop all running services
 stop:

--- a/packages/mpc-algebra-wasm/Cargo.toml
+++ b/packages/mpc-algebra-wasm/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 
 ark-ff = { git = "https://github.com/Yoii-Inc/zk-mpc.git", package = "ark-ff", version = "0.3.0" }
 ark-ec = { git = "https://github.com/Yoii-Inc/zk-mpc.git", package = "ark-ec", version = "0.3.0" }
-ark-std = { git = "https://github.com/Yoii-Inc/zk-mpc.git", package = "ark-std", version = "0.3.0", features = ["std", "print-trace"] }
+ark-std = { git = "https://github.com/Yoii-Inc/zk-mpc.git", package = "ark-std", version = "0.3.0", features = ["std"] }
 ark-crypto-primitives = { git = "https://github.com/Yoii-Inc/zk-mpc.git", package = "ark-crypto-primitives", version = "0.3.0" }
 
 ark-bls12-377 = { git = "https://github.com/Yoii-Inc/zk-mpc.git", package = "ark-bls12-377", version = "0.3.0", features = ["r1cs", "curve"] }

--- a/packages/mpc-algebra-wasm/src/lib.rs
+++ b/packages/mpc-algebra-wasm/src/lib.rs
@@ -140,7 +140,7 @@ pub fn elgamal_decrypt(input: JsValue) -> Result<JsValue, JsValue> {
 
 #[wasm_bindgen]
 pub fn fr_rand() -> Result<JsValue, JsValue> {
-    let fr = ark_bls12_377::Fr::rand(&mut ark_std::test_rng());
+    let fr = ark_bls12_377::Fr::rand(&mut ark_std::rand::thread_rng());
     let json_str = serde_json::to_string(&fr)
         .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))?;
     Ok(JsValue::from_str(&json_str))

--- a/packages/mpc-algebra-wasm/src/lib.rs
+++ b/packages/mpc-algebra-wasm/src/lib.rs
@@ -26,7 +26,8 @@ impl ark_crypto_primitives::crh::pedersen::Window for Window {
 
 type PedersenComScheme = Commitment<ark_ed_on_bls12_377::EdwardsProjective, Window>;
 type PedersenParam = <PedersenComScheme as ark_crypto_primitives::CommitmentScheme>::Parameters;
-type PedersenCommitment = <PedersenComScheme as ark_crypto_primitives::CommitmentScheme>::Output;
+pub type PedersenCommitment =
+    <PedersenComScheme as ark_crypto_primitives::CommitmentScheme>::Output;
 type PedersenRandomness =
     <PedersenComScheme as ark_crypto_primitives::CommitmentScheme>::Randomness;
 

--- a/packages/mpc-algebra-wasm/src/lib.rs
+++ b/packages/mpc-algebra-wasm/src/lib.rs
@@ -1,6 +1,7 @@
 use ark_crypto_primitives::{
-    commitment::pedersen::Commitment, encryption::AsymmetricEncryptionScheme,
+    commitment::pedersen::Commitment, encryption::AsymmetricEncryptionScheme, CommitmentScheme,
 };
+use ark_ff::{BigInteger, PrimeField, UniformRand};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
@@ -132,6 +133,38 @@ pub fn elgamal_decrypt(input: JsValue) -> Result<JsValue, JsValue> {
 
     // Serialize plaintext to JSON string and return as JsValue
     let json_str = serde_json::to_string(&plaintext)
+        .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))?;
+    Ok(JsValue::from_str(&json_str))
+}
+
+#[wasm_bindgen]
+pub fn fr_rand() -> Result<JsValue, JsValue> {
+    let fr = ark_bls12_377::Fr::rand(&mut ark_std::test_rng());
+    let json_str = serde_json::to_string(&fr)
+        .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))?;
+    Ok(JsValue::from_str(&json_str))
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PedersenCommitmentInput {
+    pub pedersen_params: PedersenParam,
+    pub x: ark_bls12_377::Fr,
+    pub pedersen_randomness: PedersenRandomness,
+}
+
+#[wasm_bindgen]
+pub fn pedersen_commitment(input: JsValue) -> Result<JsValue, JsValue> {
+    let input: PedersenCommitmentInput = serde_wasm_bindgen::from_value(input)
+        .map_err(|e| JsValue::from_str(&format!("Deserialize error: {}", e)))?;
+
+    let x_bytes = input.x.into_repr().to_bytes_le();
+
+    let commitment =
+        PedersenComScheme::commit(&input.pedersen_params, &x_bytes, &input.pedersen_randomness)
+            .map_err(|e| JsValue::from_str(&format!("Commit error: {}", e)))?;
+
+    let json_str = serde_json::to_string(&commitment)
         .map_err(|e| JsValue::from_str(&format!("Serialize error: {}", e)))?;
     Ok(JsValue::from_str(&json_str))
 }

--- a/packages/mpc-algebra-wasm/src/werewolf/types.rs
+++ b/packages/mpc-algebra-wasm/src/werewolf/types.rs
@@ -32,6 +32,40 @@ impl GroupingParameter {
         Self(input)
     }
 
+    /// Create a GroupingParameter based on the number of players.
+    /// Rules:
+    /// - FortuneTeller: 1
+    /// - Werewolf: 4-6 players → 1, 7-9 players → 2, 10-12 players → 3
+    /// - Villager: remaining players
+    pub fn from_player_count(num_players: usize) -> Self {
+        assert!(num_players >= 4, "At least 4 players are required");
+        assert!(num_players <= 12, "Maximum 12 players allowed");
+
+        let num_werewolves = if num_players <= 6 {
+            1
+        } else if num_players <= 9 {
+            2
+        } else {
+            3
+        };
+
+        let num_fortune_tellers = 1;
+        let num_villagers = num_players - num_werewolves - num_fortune_tellers;
+
+        let mut map = BTreeMap::new();
+
+        // FortuneTeller: 1 person, not a group
+        map.insert(Role::FortuneTeller, (num_fortune_tellers, false));
+
+        // Werewolf: group if multiple, not a group if single
+        map.insert(Role::Werewolf, (num_werewolves, num_werewolves > 1));
+
+        // Villager: multiple people, not a group
+        map.insert(Role::Villager, (num_villagers, false));
+
+        Self(map)
+    }
+
     // F: Field used in the MPC.
     pub fn generate_tau_matrix<F: PrimeField>(&self) -> nalgebra::DMatrix<F> {
         let num_players = self.get_num_players();

--- a/packages/nextjs/app/room/[id]/page.tsx
+++ b/packages/nextjs/app/room/[id]/page.tsx
@@ -12,6 +12,7 @@ import { useGameChat } from "~~/hooks/useGameChat";
 import { useGameInfo } from "~~/hooks/useGameInfo";
 import { useGamePhase } from "~~/hooks/useGamePhase";
 import { useGameWebSocket } from "~~/hooks/useGameWebSocket";
+import * as GameInputGenerator from "~~/services/gameInputGenerator";
 import type { ChatMessage } from "~~/types/game";
 import { TweetNaclKeyManager } from "~~/utils/crypto/tweetNaclKeyManager";
 
@@ -52,9 +53,15 @@ export default function RoomPage({ params }: { params: { id: string } }) {
 
   // ゲームリセット通知を監視
   useEffect(() => {
-    const handleGameReset = () => {
-      console.log("Game reset notification received, clearing messages");
+    const handleGameReset = (event: Event) => {
+      const customEvent = event as CustomEvent;
+      const { roomId } = customEvent.detail;
+
+      console.log("Game reset notification received, clearing messages and crypto state");
       resetMessages();
+
+      // 暗号パラメータとランダムネスの初期化状態をリセット
+      GameInputGenerator.resetGameCryptoState(roomId);
     };
 
     window.addEventListener("gameResetNotification", handleGameReset);

--- a/packages/nextjs/hooks/useGameWebSocket.ts
+++ b/packages/nextjs/hooks/useGameWebSocket.ts
@@ -48,6 +48,24 @@ export const useGameWebSocket = (
         return;
       }
 
+      // コミットメント準備完了通知の場合
+      if (data.message_type === "commitments_ready") {
+        console.log(`Commitments ready notification received: ${data.commitments_count}/${data.total_players} players`);
+
+        // カスタムイベントを発行
+        window.dispatchEvent(
+          new CustomEvent("commitmentsReadyNotification", {
+            detail: {
+              roomId: data.room_id,
+              commitmentsCount: data.commitments_count,
+              totalPlayers: data.total_players,
+              timestamp: data.timestamp,
+            },
+          }),
+        );
+        return;
+      }
+
       // For computation result notification
       if (data.message_type === "computation_result") {
         console.log(`Computation result notification received: ${data.computation_type}`);

--- a/packages/nextjs/services/gameInputGenerator.ts
+++ b/packages/nextjs/services/gameInputGenerator.ts
@@ -364,7 +364,8 @@ export async function submitCommitment(
   playerIdString: string,
 ): Promise<void> {
   const params = await loadCryptoParams();
-  console.log("Submitting commitment for player index:", params);
+  console.log("Submitting commitment for player index:", playerIndex);
+  console.log("Loaded crypto params for commitment:", params);
   if (!params?.pedersenParam) {
     throw new Error("Pedersen parameters not available");
   }

--- a/packages/nextjs/services/gameInputGenerator.ts
+++ b/packages/nextjs/services/gameInputGenerator.ts
@@ -58,6 +58,14 @@ const randomnessCache = new Map<string, Field[]>();
 export async function loadCryptoParams(gameInfo?: GameInfo): Promise<any> {
   if (cryptoParamsCache) {
     console.log("Using cached crypto params");
+    // If gameInfo has updated player commitments, refresh that piece of cache
+    const gp = gameInfo?.crypto_parameters;
+    if (gp && gp.player_commitment) {
+      cryptoParamsCache.playerCommitments = gp.player_commitment;
+      // keep pedersenCommitment in sync with first element if available
+      cryptoParamsCache.pedersenCommitment = gp.player_commitment?.[0] ?? cryptoParamsCache.pedersenCommitment;
+      console.log("Updated cached playerCommitments from gameInfo");
+    }
     return cryptoParamsCache;
   }
 
@@ -72,6 +80,7 @@ export async function loadCryptoParams(gameInfo?: GameInfo): Promise<any> {
       pedersenRandomness: null, // ランダムネスは別途管理
       elgamalParam: gp.elgamal_param,
       elgamalPublicKey: gp.fortune_teller_public_key,
+      playerCommitments: gp.player_commitment,
     };
 
     console.log("Crypto params loaded successfully from gameInfo");
@@ -449,7 +458,7 @@ export async function generateRoleAssignmentInput(
     groupingParameter,
     tauMatrix: generatedTau,
     roleCommitment: parsedRinput.publicInput.roleCommitment,
-    playerCommitment: parsedRinput.publicInput.playerCommitment,
+    playerCommitment: cryptoParams.playerCommitments,
   };
 
   return {

--- a/packages/nextjs/types/game.ts
+++ b/packages/nextjs/types/game.ts
@@ -45,6 +45,7 @@ export interface GameInfo {
       message_type: string;
     }>;
   };
+  grouping_parameter?: GroupingParameter;
 }
 
 export interface PrivateGameInfo {
@@ -81,4 +82,10 @@ export interface WebSocketMessage {
 export interface GameResultModalProps {
   result: "VillagerWin" | "WerewolfWin" | "InProgress";
   onClose: () => void;
+}
+
+export interface GroupingParameter {
+  Villager: [number, boolean];
+  FortuneTeller: [number, boolean];
+  Werewolf: [number, boolean];
 }

--- a/packages/nextjs/utils/crypto/InputEncryption.ts
+++ b/packages/nextjs/utils/crypto/InputEncryption.ts
@@ -4,6 +4,7 @@ import init, {
   init as RustInit,
   divination,
   elgamal_decrypt,
+  fr_rand,
   key_publicize,
   role_assignment,
   voting_split_and_encrypt,
@@ -114,6 +115,20 @@ export class MPCEncryption {
     } catch (error) {
       console.error("ElGamal decryption failed:", error);
       throw new Error(`Failed to decrypt ElGamal cipher: ${error}`);
+    }
+  }
+
+  /**
+   * Fr random generator
+   */
+  public static async frRand(): Promise<any> {
+    await this.initializeWasm();
+    try {
+      const result = fr_rand();
+      return JSON.parse(result);
+    } catch (error) {
+      console.error("Fr random generation failed:", error);
+      throw new Error(`Failed to generate Fr random: ${error}`);
     }
   }
 }

--- a/packages/nextjs/utils/crypto/InputEncryption.ts
+++ b/packages/nextjs/utils/crypto/InputEncryption.ts
@@ -6,6 +6,7 @@ import init, {
   elgamal_decrypt,
   fr_rand,
   key_publicize,
+  pedersen_commitment,
   role_assignment,
   voting_split_and_encrypt,
   winning_judgement,
@@ -129,6 +130,21 @@ export class MPCEncryption {
     } catch (error) {
       console.error("Fr random generation failed:", error);
       throw new Error(`Failed to generate Fr random: ${error}`);
+    }
+  }
+
+  /**
+   * Pedersen commitment wrapper
+   * Expects input: { pedersen_params, x, pedersen_randomness }
+   */
+  public static async pedersenCommitment(input: any): Promise<any> {
+    await this.initializeWasm();
+    try {
+      const result = pedersen_commitment(input);
+      return JSON.parse(result);
+    } catch (error) {
+      console.error("Pedersen commitment failed:", error);
+      throw new Error(`Failed to compute pedersen commitment`);
     }
   }
 }

--- a/packages/nextjs/utils/crypto/type.ts
+++ b/packages/nextjs/utils/crypto/type.ts
@@ -100,7 +100,7 @@ export interface AnonymousVotingPrivateInput {
   id: number;
   //   isTargetId: string[];
   isTargetId: Field[][];
-  playerRandomness: (number[] | null)[];
+  playerRandomness: Field[];
 }
 export interface AnonymousVotingPublicInput {
   pedersenParam: PedersenParam;
@@ -123,7 +123,7 @@ export interface RoleAssignmentPrivateInput {
   id: number;
   shuffleMatrices: any;
   randomness: any;
-  playerRandomness: number[] | null;
+  playerRandomness: Field[];
 }
 export interface RoleAssignmentPublicInput {
   // parameter

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -40,6 +40,7 @@ pub struct Game {
     pub batch_request: BatchRequest,
     pub computation_results: ComputationResults,
     pub started_at: Option<DateTime<Utc>>,
+    pub grouping_parameter: GroupingParameter,
 }
 
 // 計算結果を管理する構造体群
@@ -285,6 +286,7 @@ pub enum BatchStatus {
 
 impl Game {
     pub fn new(room_id: String, players: Vec<Player>) -> Self {
+        let player_count = players.len();
         Game {
             room_id: room_id.clone(),
             name: "".to_string(),
@@ -301,6 +303,7 @@ impl Game {
             batch_request: BatchRequest::new(),
             computation_results: ComputationResults::default(),
             started_at: Some(Utc::now()),
+            grouping_parameter: GroupingParameter::from_player_count(player_count),
         }
     }
 

--- a/packages/server/src/routes/game.rs
+++ b/packages/server/src/routes/game.rs
@@ -624,7 +624,6 @@ async fn submit_commitment(
         }
 
         // コミットメントをデシリアライズしてCryptoParameters.player_commitmentに追加
-        // TODO: 現状はJSON文字列をログに記録するのみ（deserializeの実装が必要）
         tracing::info!(
             "Received commitment from player {} (index: {}) in room {}: {:?}",
             commitment_req.player_id,

--- a/packages/server/src/routes/game.rs
+++ b/packages/server/src/routes/game.rs
@@ -4,6 +4,7 @@ use crate::models::game::{
 };
 use crate::models::role::Role;
 use crate::models::room::RoomStatus;
+use crate::services::game_service::initialize_crypto_parameters;
 use crate::services::zk_proof;
 use crate::{
     models::chat::{ChatMessage, ChatMessageType},
@@ -297,7 +298,7 @@ async fn reset_game_handler(
 
         // ゲームを更新
         // reset crypto parameters as well
-        reset_game.crypto_parameters = None;
+        initialize_crypto_parameters(&mut reset_game);
         *game = reset_game;
 
         // ルームも更新

--- a/packages/server/src/services/game_service.rs
+++ b/packages/server/src/services/game_service.rs
@@ -590,7 +590,7 @@ pub async fn preprocessing_werewolf(state: AppState, game: &mut Game) -> Result<
 }
 
 // 暗号パラメータの初期化関数
-fn initialize_crypto_parameters(game: &mut Game) {
+pub fn initialize_crypto_parameters(game: &mut Game) {
     let mut rng = rand::thread_rng();
 
     // Pedersenコミットメントパラメータの生成

--- a/packages/server/src/state.rs
+++ b/packages/server/src/state.rs
@@ -66,6 +66,31 @@ impl AppState {
         Ok(())
     }
 
+    pub async fn broadcast_commitments_ready(
+        &self,
+        room_id: &str,
+        commitments_count: usize,
+        total_players: usize,
+    ) -> Result<(), String> {
+        let tx = self.get_or_create_room_channel(room_id).await;
+
+        let commitments_ready_notification = serde_json::json!({
+            "message_type": "commitments_ready",
+            "room_id": room_id,
+            "commitments_count": commitments_count,
+            "total_players": total_players,
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        });
+
+        if let Ok(message_text) = serde_json::to_string(&commitments_ready_notification) {
+            if let Err(e) = tx.send(Message::Text(message_text)) {
+                return Err(format!("Failed to broadcast commitments ready: {}", e));
+            }
+        }
+
+        Ok(())
+    }
+
     pub async fn broadcast_computation_result(
         &self,
         room_id: &str,

--- a/packages/zk-mpc-node/src/node.rs
+++ b/packages/zk-mpc-node/src/node.rs
@@ -37,8 +37,10 @@ impl<IO: AsyncRead + AsyncWrite + Unpin + Send + 'static> Node<IO> {
                 // Base64デコード
                 let private_key_bytes = base64::decode(&private_key_base64)
                     .expect("Failed to decode MPC_PRIVATE_KEY from base64");
-                let public_key_bytes = base64::decode(&public_key_base64)
-                    .expect(&format!("Failed to decode {} from base64", public_key_env_name));
+                let public_key_bytes = base64::decode(&public_key_base64).expect(&format!(
+                    "Failed to decode {} from base64",
+                    public_key_env_name
+                ));
 
                 key_manager
                     .set_keys_from_base64_bytes(private_key_bytes, public_key_bytes)


### PR DESCRIPTION
# Summary

This PR implements a synchronization and reset flow around player Pedersen commitments and client-side crypto state.

## Goals
- Ensure the server collects each player's Pedersen commitment and notifies all clients when all commitments have been received.
- Make clients wait for the server's "commitments ready" notification before submitting the role-assignment request.
- When the game is reset by any client, clear client-side crypto caches and per-room randomness in LocalStorage for all clients so every client re-initializes cleanly.

## Server-side changes
- Add `broadcast_commitments_ready` to `AppState` to broadcast a `commitments_ready` WebSocket message to a room.
- Update the `/game/{room}/commitment` endpoint to deserialize incoming commitments into `game.crypto_parameters.player_commitment` and call `broadcast_commitments_ready` when all players' commitments are present.

Affected files:
- `packages/server/src/state.rs`
- `packages/server/src/routes/game.rs`

## Client-side changes
- WebSocket: handle `commitments_ready` and emit a `commitmentsReadyNotification` custom event.
  - `packages/nextjs/hooks/useGameWebSocket.ts`

- Phase handling: add `commitmentsReadyRef` flag and, on `Waiting -> Night` transitions, wait up to 30s for the commitments-ready flag before calling role assignment. Reset the flag on `game_reset`.
  - `packages/nextjs/hooks/useGamePhase.ts`

- Crypto cache and reset: add `resetGameCryptoState(roomId)` to clear `cryptoParamsCache`, `randomnessCache`, and per-room randomness entries from `localStorage`. Call this when receiving `game_reset`.
  - `packages/nextjs/services/gameInputGenerator.ts`
  - `packages/nextjs/app/room/[id]/page.tsx`

- Role-assignment input: `generateRoleAssignmentInput` now fetches the latest `/game/{room}/state` and uses `crypto_parameters.player_commitment` from the server when available. Missing commitments are filled with dummy commitments so arrays match player count.
  - `packages/nextjs/services/gameInputGenerator.ts`

## Flow
1. Each client computes and submits its Pedersen commitment to `/game/{room}/commitment`.
2. Server stores commitments into `game.crypto_parameters.player_commitment`.
3. When all commitments are present, server broadcasts `commitments_ready` to the room.
4. Clients set a local `commitmentsReady` flag upon receiving the message.
5. On `Waiting -> Night` phase transition, clients wait (up to 30s) for `commitmentsReady` and then call `submitRoleAssignment`.
6. On game reset, clients clear crypto caches and local randomness so subsequent initialization is fresh.

## Notes
- Server `CryptoParameters` serialization is a TODO in the codebase; if clients still see empty commitments, verify server serialization for the commitment type.
- Lint/pre-commit hooks flagged a few warnings; one `require` usage was replaced by a static import.

---

If you want, I can update the PR body further (shorter summary, add screenshots, add testing instructions), or push additional commits to the PR branch.