### PR TITLE
Improve proof batch handling and phase acceptance

### DIFF
--- a/packages/mpc-circuits/src/traits/circuits.rs
+++ b/packages/mpc-circuits/src/traits/circuits.rs
@@ -29,13 +29,18 @@ use mpc_algebra::{BitDecomposition, BooleanWire};
 use mpc_algebra::{EqualityZero, ModulusConversion};
 use mpc_algebra_wasm::{calc_shuffle_matrix, Role};
 use nalgebra as na;
+use std::collections::HashSet;
 use zk_mpc::circuits::{ElGamalLocalOrMPC, LocalOrMPC};
 use zk_mpc::field::*;
 
 impl AnonymousVotingCircuit<Fr> {
     pub fn calculate_output(&self) -> Fr {
-        let player_num = self.private_input.len(); // Assuming all players join generation
-        let alive_player_num = player_num; // Assuming all players are alive for simplicity
+        if self.private_input.is_empty() {
+            return Fr::zero();
+        }
+
+        let player_num = self.private_input[0].is_target_id.len();
+        let alive_player_num = self.private_input.len();
 
         let mut num_voted = vec![Fr::zero(); player_num];
 
@@ -60,8 +65,12 @@ impl AnonymousVotingCircuit<Fr> {
 
 impl AnonymousVotingCircuit<MpcField<Fr>> {
     pub fn calculate_output(&self) -> MpcField<Fr> {
-        let player_num = self.private_input.len(); // Assuming all players join generation
-        let alive_player_num = player_num; // Assuming all players are alive for simplicity
+        if self.private_input.is_empty() {
+            return MpcField::<Fr>::zero();
+        }
+
+        let player_num = self.private_input[0].is_target_id.len();
+        let alive_player_num = self.private_input.len();
 
         let mut num_voted = vec![MpcField::<Fr>::zero(); player_num];
 
@@ -395,7 +404,21 @@ impl ConstraintSynthesizer<Fr> for DivinationCircuit<Fr> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let is_target_sum_bit = (0..is_target_bit[0].len())
+        let player_num = is_target_bit[0].len();
+        let row_ids = self
+            .private_input
+            .iter()
+            .map(|input| input.id)
+            .collect::<Vec<_>>();
+
+        let mut seen_row_ids = HashSet::new();
+        for id in &row_ids {
+            if *id >= player_num || !seen_row_ids.insert(*id) {
+                return Err(SynthesisError::Unsatisfiable);
+            }
+        }
+
+        let is_target_sum_bit = (0..player_num)
             .map(|j| {
                 Boolean::kary_or(
                     &is_target_bit
@@ -408,8 +431,8 @@ impl ConstraintSynthesizer<Fr> for DivinationCircuit<Fr> {
 
         let is_wt = is_werewolf_bit
             .iter()
-            .zip(is_target_sum_bit.iter())
-            .map(|(x, y)| x.and(y))
+            .enumerate()
+            .map(|(row_index, x)| x.and(&is_target_sum_bit[row_ids[row_index]]))
             .collect::<Result<Vec<_>, _>>()?;
 
         let is_target_werewolf_bit = Boolean::kary_or(is_wt.as_slice())?;
@@ -481,7 +504,7 @@ impl ConstraintSynthesizer<Fr> for DivinationCircuit<Fr> {
         let enc_result_var2 = <Fr as ElGamalLocalOrMPC<Fr>>::ElGamalCiphertextVar::new_input(
             ark_relations::ns!(cs, "gadget_commitment"),
             || {
-                let sum_target = (0..self.private_input.len())
+                let sum_target = (0..player_num)
                     .map(|i| {
                         let mut tmp = Fr::from(0);
                         for j in 0..self.private_input.len() {
@@ -493,9 +516,8 @@ impl ConstraintSynthesizer<Fr> for DivinationCircuit<Fr> {
                 let is_werewolf: Fr = self
                     .private_input
                     .iter()
-                    .map(|input| input.is_werewolf)
-                    .zip(sum_target.iter())
-                    .map(|(x, y)| x * y)
+                    .zip(row_ids.iter())
+                    .map(|(input, id)| input.is_werewolf * sum_target[*id])
                     .sum();
 
                 let message = match is_werewolf.is_one() {
@@ -559,7 +581,21 @@ impl ConstraintSynthesizer<MpcField<Fr>> for DivinationCircuit<MpcField<Fr>> {
             .map(|input| MpcBoolean::new_witness_vec(cs.clone(), &input.is_target))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let is_target_sum_bit = (0..is_target_bit[0].len())
+        let player_num = is_target_bit[0].len();
+        let row_ids = self
+            .private_input
+            .iter()
+            .map(|input| input.id)
+            .collect::<Vec<_>>();
+
+        let mut seen_row_ids = HashSet::new();
+        for id in &row_ids {
+            if *id >= player_num || !seen_row_ids.insert(*id) {
+                return Err(SynthesisError::Unsatisfiable);
+            }
+        }
+
+        let is_target_sum_bit = (0..player_num)
             .map(|j| {
                 MpcBoolean::kary_or(
                     &is_target_bit
@@ -572,8 +608,8 @@ impl ConstraintSynthesizer<MpcField<Fr>> for DivinationCircuit<MpcField<Fr>> {
 
         let is_wt = is_werewolf_bit
             .iter()
-            .zip(is_target_sum_bit.iter())
-            .map(|(x, y)| x.and(y))
+            .enumerate()
+            .map(|(row_index, x)| x.and(&is_target_sum_bit[row_ids[row_index]]))
             .collect::<Result<Vec<_>, _>>()?;
 
         let is_target_werewolf_bit = MpcBoolean::kary_or(is_wt.as_slice())?;
@@ -650,7 +686,7 @@ impl ConstraintSynthesizer<MpcField<Fr>> for DivinationCircuit<MpcField<Fr>> {
             <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalCiphertextVar::new_input(
                 ark_relations::ns!(cs, "gadget_commitment"),
                 || {
-                    let sum_target = (0..self.private_input.len())
+                    let sum_target = (0..player_num)
                         .map(|i| {
                             let mut tmp = MpcField::<Fr>::from(0u32);
                             for j in 0..self.private_input.len() {
@@ -659,20 +695,18 @@ impl ConstraintSynthesizer<MpcField<Fr>> for DivinationCircuit<MpcField<Fr>> {
                             tmp
                         })
                         .collect::<Vec<_>>();
-                    let is_werewolf: MpcField<Fr> = self
+                    let mut is_werewolf: MpcField<Fr> = self
                         .private_input
                         .iter()
-                        .map(|input| input.is_werewolf)
-                        .zip(sum_target.iter())
-                        .map(|(x, y)| x * y)
+                        .zip(row_ids.iter())
+                        .map(|(input, id)| input.is_werewolf * sum_target[*id])
                         .sum();
 
-                    let message = match is_werewolf.is_one() {
-                    true => {
-                        <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalPlaintext::prime_subgroup_generator()
-                    }
-                    false => <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalPlaintext::default(),
-                };
+                    // Assumes is_werewolf is binary (0/1). If it is not, this becomes k*G (k != 0/1).
+                    let is_werewolf_scalar = is_werewolf.sync_modulus_conversion();
+                    let base =
+                        <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalPlaintext::prime_subgroup_generator();
+                    let message = base.scalar_mul(is_werewolf_scalar).into();
                     let enc_result =
                         <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalScheme::encrypt(
                             &self.public_input.elgamal_param,
@@ -1080,37 +1114,40 @@ impl DivinationCircuit<MpcField<Fr>> {
     pub fn calculate_output(
         &self,
     ) -> <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalCiphertext {
-        let _is_target_vec = self
-            .private_input
-            .iter()
-            .map(|input| input.is_target.clone())
-            .collect::<Vec<_>>();
-        let _is_werewolf_vec = self
-            .private_input
-            .iter()
-            .map(|input| input.is_werewolf)
-            .collect::<Vec<_>>();
+        let player_num = self.private_input[0].is_target.len();
+        let mut seen_row_ids = HashSet::new();
+        for input in &self.private_input {
+            assert!(
+                input.id < player_num,
+                "Divination input id {} out of range {}",
+                input.id,
+                player_num
+            );
+            assert!(
+                seen_row_ids.insert(input.id),
+                "Duplicate divination input id {} detected",
+                input.id
+            );
+        }
+
+        let mut sum_target = vec![MpcField::<Fr>::zero(); player_num];
+        for i in 0..player_num {
+            for j in 0..self.private_input.len() {
+                sum_target[i] += self.private_input[j].is_target[i];
+            }
+        }
 
         let mut sum = MpcField::<Fr>::default();
-
-        for i in 0..self.private_input.len() {
-            let mut tmp = MpcField::<Fr>::default();
-            for j in 0..self.private_input.len() {
-                tmp += self.private_input[j].is_target[i];
-            }
-            sum += tmp * self.private_input[i].is_werewolf;
+        for input in &self.private_input {
+            sum += sum_target[input.id] * input.is_werewolf;
         }
 
         let pub_key = self.public_input.pub_key;
 
+        // Assumes sum is binary (0/1). If it is not, this becomes k*G (k != 0/1).
+        let sum_scalar = sum.sync_modulus_conversion();
         let base = <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalPlaintext::prime_subgroup_generator();
-
-        // TODO: implement correctly. (without reveal)
-        let message = if sum.sync_reveal().is_one() {
-            base
-        } else {
-            <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalPlaintext::default()
-        };
+        let message = base.scalar_mul(sum_scalar).into();
 
         let ciphertext = <MpcField<Fr> as ElGamalLocalOrMPC<MpcField<Fr>>>::ElGamalScheme::encrypt(
             &self.public_input.elgamal_param,

--- a/packages/nextjs/__tests__/e2e/circuits/helpers/api.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/helpers/api.ts
@@ -406,7 +406,13 @@ export class CircuitTestClient {
    * Divinationリクエストを送信
    * 本番環境では useDivination フックが行う処理
    */
-  async submitDivination(roomId: string, divinationInput: any, playerCount: number, authToken?: string): Promise<any> {
+  async submitDivination(
+    roomId: string,
+    divinationInput: any,
+    playerCount: number,
+    authToken?: string,
+    isDummy = false,
+  ): Promise<any> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
@@ -424,6 +430,7 @@ export class CircuitTestClient {
         user_id: String(divinationInput.privateInput.id),
         prover_count: playerCount,
         encrypted_data: encryptedDivination,
+        is_dummy: isDummy,
       },
     };
 

--- a/packages/nextjs/__tests__/e2e/circuits/helpers/game-setup.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/helpers/game-setup.ts
@@ -228,7 +228,7 @@ export class GameSetupHelper {
         );
 
         console.log(`   📤 Submitting Divination request for ${player.name}...`);
-        await apiClient.submitDivination(roomId, divinationInput, players.length, player.token);
+        await apiClient.submitDivination(roomId, divinationInput, players.length, player.token, isDummy);
         console.log(`   ✅ ${player.name} Divination request sent`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/nextjs/__tests__/e2e/circuits/setup.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/setup.ts
@@ -120,7 +120,8 @@ async function openTestWebSockets(roomId: string, players: TestPlayer[]): Promis
             try {
               // Node.js 'ws' の場合は event.data が Buffer なので文字列に変換
               const dataStr = typeof event === "string" ? event : event.data?.toString() || event.toString();
-              const data = JSON.parse(dataStr);
+              const rawData = JSON.parse(dataStr);
+              const data = rawData?.payload && rawData?.event_id ? rawData.payload : rawData;
 
               console.log(`   📩 [${player.name}] WebSocket message:`, data.message_type);
 

--- a/packages/nextjs/app/room/[id]/page.tsx
+++ b/packages/nextjs/app/room/[id]/page.tsx
@@ -796,7 +796,6 @@ export default function RoomPage({ params }: { params: { id: string } }) {
           players={gameInfo.players}
           role={privateGameInfo?.playerRole ?? "Villager"}
           gameInfo={gameInfo}
-          username={user?.username ?? ""}
           onSubmit={() => {
             // handleNightAction(targetPlayerId, privateGameInfo?.playerRole);
             setShowNightAction(false);

--- a/packages/nextjs/components/game/NightActionModal.tsx
+++ b/packages/nextjs/components/game/NightActionModal.tsx
@@ -1,15 +1,11 @@
 import React, { useState } from "react";
 import type { Player, Role } from "../../app/types";
-import { useGameInputGenerator } from "../../hooks/useGameInputGenerator";
-import { useBackgroundNightAction } from "~~/hooks/useBackgroundNightAction";
-import { useDivination } from "~~/hooks/useDivination";
 import type { GameInfo } from "~~/types/game";
 
 interface NightActionModalProps {
   players: Player[];
   role: Role;
   gameInfo: GameInfo;
-  username: string;
   onSubmit: (targetPlayerId: string) => void;
   onClose: () => void;
   roomId: string;
@@ -20,7 +16,6 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
   players,
   role,
   gameInfo,
-  username,
   onSubmit,
   onClose,
   roomId,
@@ -28,9 +23,6 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
 }) => {
   const [selectedPlayer, setSelectedPlayer] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const { submitDivination, error, proofStatus } = useDivination();
-  const { handleBackgroundNightAction } = useBackgroundNightAction();
-  const { isReady, generateDivinationInput } = useGameInputGenerator(roomId, username, gameInfo);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,29 +33,10 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
     try {
       // 占い師の場合は占い処理を行う
       if (role === "Seer") {
-        if (!isReady) {
-          throw new Error("Game crypto is not ready");
-        }
-
-        // 占い対象をlocalStorageに保存（結果受信時に使用）
-        localStorage.setItem(`divination_target_${roomId}`, selectedPlayer);
-        const targetPlayerName = players.find(p => p.id === selectedPlayer)?.name || "Unknown";
-        localStorage.setItem(`divination_target_name_${roomId}`, targetPlayerName);
-        console.log("Divination target saved to localStorage:", selectedPlayer, targetPlayerName);
-
-        // 占いデータを生成
-        const divinationData = await generateDivinationInput(selectedPlayer, false);
-
-        console.log("占いデータ:", divinationData);
-
-        if (!divinationData) {
-          throw new Error("Failed to generate divination data");
-        }
-
-        const alivePlayerCount = players.filter(player => !player.is_dead).length;
-
-        console.log("Executing divination.");
-        await submitDivination(roomId, divinationData, alivePlayerCount);
+        // 占い師は夜フェーズでは送信せず、遷移時に全員同時送信する。
+        const dayCount = gameInfo.day_count ?? 0;
+        localStorage.setItem(`pending_divination_target_${roomId}_${dayCount}`, selectedPlayer);
+        console.log(`Divination target saved for synchronized submission: room=${roomId}, day=${dayCount}`);
       }
       // 人狼の場合は襲撃処理を行う
       else if (role === "Werewolf") {
@@ -104,7 +77,9 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
     } finally {
       setIsSubmitting(false);
     }
-  }; // Filter selectable players based on role
+  };
+
+  // Filter selectable players based on role
   const selectablePlayers = players.filter(p => {
     if (p.is_dead === true) return false;
     if (p.id === myId) return false; // 自分自身は選択できない

--- a/packages/nextjs/hooks/useBackgroundNightAction.ts
+++ b/packages/nextjs/hooks/useBackgroundNightAction.ts
@@ -3,18 +3,50 @@ import { Player } from "../app/types";
 import * as GameInput from "~~/services/gameInputGenerator";
 import { GameInfo } from "~~/types/game";
 import { MPCEncryption } from "~~/utils/crypto/InputEncryption";
+import { getPrivateGameInfo } from "~~/utils/privateGameInfoUtils";
+
+const pendingDivinationTargetKey = (roomId: string, dayCount: number): string =>
+  `pending_divination_target_${roomId}_${dayCount}`;
 
 export const useBackgroundNightAction = () => {
   const handleBackgroundNightAction = useCallback(
     async (roomId: string, myId: string, players: Player[], username: string, gameInfo: GameInfo) => {
       try {
+        const dayCount = gameInfo.day_count ?? 0;
+        const privateGameInfo = getPrivateGameInfo(roomId, myId);
+        const isSeer = privateGameInfo?.playerRole === "Seer";
+
+        const pendingTargetId = localStorage.getItem(pendingDivinationTargetKey(roomId, dayCount));
+
         // ダミーターゲットとして最初の生存プレイヤーを選択
         const dummyTargetId = players.find(p => !p.is_dead && p.id !== myId)?.id || players[0].id;
+        const hasSeerSelection = isSeer && typeof pendingTargetId === "string" && pendingTargetId.length > 0;
+        const selectedTargetId = hasSeerSelection ? (pendingTargetId as string) : dummyTargetId;
+        const isDummy = !hasSeerSelection;
 
-        console.log(`Generating dummy divination for player ${myId}, target: ${dummyTargetId}`);
-        const divinationData = await GameInput.generateDivinationInput(roomId, username, gameInfo, dummyTargetId, true);
+        if (hasSeerSelection) {
+          const targetPlayerName = players.find(p => p.id === selectedTargetId)?.name || "Unknown";
+          localStorage.setItem(`divination_target_${roomId}`, selectedTargetId);
+          localStorage.setItem(`divination_target_name_${roomId}`, targetPlayerName);
+          localStorage.removeItem(pendingDivinationTargetKey(roomId, dayCount));
+          console.log(
+            `Submitting synchronized divination for Seer ${myId}, day=${dayCount}, target=${selectedTargetId}`,
+          );
+        } else {
+          localStorage.removeItem(`divination_target_${roomId}`);
+          localStorage.removeItem(`divination_target_name_${roomId}`);
+          console.log(`Submitting dummy divination for player ${myId}, day=${dayCount}`);
+        }
 
-        console.log("占いダミーデータ:", divinationData);
+        const divinationData = await GameInput.generateDivinationInput(
+          roomId,
+          username,
+          gameInfo,
+          selectedTargetId,
+          isDummy,
+        );
+
+        console.log("Divination data for synchronized submission:", divinationData);
 
         if (!divinationData) {
           throw new Error("Failed to generate divination data");
@@ -26,7 +58,9 @@ export const useBackgroundNightAction = () => {
 
         const alivePlayerCount = players.filter(player => !player.is_dead).length;
 
-        console.log(`Sending dummy divination request to server (alive players: ${alivePlayerCount})`);
+        console.log(
+          `Sending synchronized divination request to server (alive players: ${alivePlayerCount}, is_dummy: ${isDummy})`,
+        );
         // バックエンドにリクエスト送信
         const response = await fetch(
           `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api"}/game/${roomId}/proof`,
@@ -41,6 +75,7 @@ export const useBackgroundNightAction = () => {
                 user_id: String(divinationData.privateInput.id),
                 prover_count: alivePlayerCount,
                 encrypted_data: encryptedDivination,
+                is_dummy: isDummy,
               },
             }),
           },
@@ -52,7 +87,7 @@ export const useBackgroundNightAction = () => {
           throw new Error(`Failed to send night action: ${response.status} ${errorText}`);
         }
 
-        console.log("Dummy divination request sent successfully");
+        console.log("Synchronized divination request sent successfully");
       } catch (error) {
         console.error("Background night action error:", error);
         throw error; // エラーを再スロー

--- a/packages/nextjs/hooks/useDivination.ts
+++ b/packages/nextjs/hooks/useDivination.ts
@@ -41,6 +41,7 @@ export const useDivination = () => {
                 user_id: String(divinationData.privateInput.id),
                 prover_count: alivePlayerCount,
                 encrypted_data: encryptedDivination,
+                is_dummy: false,
               },
             }),
           },

--- a/packages/nextjs/hooks/useGameInfo.ts
+++ b/packages/nextjs/hooks/useGameInfo.ts
@@ -134,22 +134,34 @@ export const useGameInfo = (
   }, [fetchGameInfo, fetchRoomInfo, roomInfo?.status]);
 
   useEffect(() => {
-    fetchRoomInfo();
-    const roomInterval = setInterval(fetchRoomInfo, 5000);
+    void refetchRoomAndGame();
+  }, [refetchRoomAndGame]);
 
-    let gameInterval: NodeJS.Timeout | null = null;
-    if (roomInfo?.status === "InProgress") {
-      fetchGameInfo();
-      gameInterval = setInterval(fetchGameInfo, 5000);
-    }
+  useEffect(() => {
+    const handleServerDrivenRefresh = () => {
+      void refetchRoomAndGame();
+    };
+
+    const events = [
+      "phaseChangeNotification",
+      "commitmentsReadyNotification",
+      "computationResultNotification",
+      "proofJobStatusNotification",
+      "roomStateChangedNotification",
+      "gameResetNotification",
+      "wsEventGapDetected",
+    ];
+
+    events.forEach(eventName => {
+      window.addEventListener(eventName, handleServerDrivenRefresh);
+    });
 
     return () => {
-      clearInterval(roomInterval);
-      if (gameInterval) {
-        clearInterval(gameInterval);
-      }
+      events.forEach(eventName => {
+        window.removeEventListener(eventName, handleServerDrivenRefresh);
+      });
     };
-  }, [fetchGameInfo, fetchRoomInfo, roomInfo?.status]);
+  }, [refetchRoomAndGame]);
 
   return { roomInfo, gameInfo, privateGameInfo, isLoading, setGameInfo, refetchRoomAndGame };
 };

--- a/packages/nextjs/hooks/useGamePhase.ts
+++ b/packages/nextjs/hooks/useGamePhase.ts
@@ -208,7 +208,7 @@ export const useGamePhase = (
         handleRoleAssignment();
       }
 
-      // Step 1: ダミーリクエスト送信
+      // Step 1: Divinationリクエスト送信（全員同時送信）
       if (
         requiresDummyRequest &&
         fromPhase === "Night" &&
@@ -216,7 +216,7 @@ export const useGamePhase = (
         !currentPlayer.is_dead
       ) {
         processingSteps.push(async () => {
-          console.log(`Step 1: Player ${username} sending dummy request.`);
+          console.log(`Step 1: Player ${username} sending synchronized divination request.`);
 
           try {
             await handleBackgroundNightAction(
@@ -227,14 +227,14 @@ export const useGamePhase = (
               latestGameInfo,
             );
 
-            console.log("Step 1: Dummy request completed");
+            console.log("Step 1: Synchronized divination request completed");
           } catch (error) {
-            console.error("Step 1: Dummy request error:", error);
+            console.error("Step 1: Synchronized divination request error:", error);
             // TODO: サーバー側でエラーメッセージを送るようになったら削除
             addMessage({
               id: Date.now().toString(),
               sender: "System",
-              message: "Failed to send dummy request",
+              message: "Failed to send synchronized divination request",
               timestamp: new Date().toISOString(),
               type: "system",
             });

--- a/packages/nextjs/hooks/useGameWebSocket.ts
+++ b/packages/nextjs/hooks/useGameWebSocket.ts
@@ -134,10 +134,27 @@ export const useGameWebSocket = (
         const incomingEventId = parsed.event_id;
         const lastEventId = lastEventIdRef.current;
 
-        if (incomingEventId <= lastEventId) {
+        // Handle duplicate and reset scenarios before normal gap detection.
+        if (incomingEventId === lastEventId) {
+          // Exact duplicate of the last event we've already processed.
           return;
         }
 
+        if (incomingEventId < lastEventId) {
+          // The server's event_id counter appears to have reset (e.g. after restart)
+          // while the client still has a larger lastEventId persisted. Reset our
+          // local tracking so we can resume processing events from the server.
+          lastEventIdRef.current = 0;
+          persistLastEventId(roomId, 0);
+
+          if (onReconnectRef.current) {
+            void Promise.resolve(onReconnectRef.current()).catch(error => {
+              console.error("Failed to recover after WebSocket stream reset:", error);
+            });
+          }
+          // Do not return here: treat this incoming event as the first event
+          // after a reset and allow it to be processed below.
+        }
         if (lastEventId > 0 && incomingEventId > lastEventId + 1) {
           const detail = {
             expectedEventId: lastEventId + 1,

--- a/packages/nextjs/hooks/useGameWebSocket.ts
+++ b/packages/nextjs/hooks/useGameWebSocket.ts
@@ -5,15 +5,60 @@ type WebSocketStatus = "disconnected" | "connecting" | "connected" | "reconnecti
 
 interface UseGameWebSocketOptions {
   onReconnect?: () => void | Promise<void>;
+  onGapDetected?: (detail: { expectedEventId: number; receivedEventId: number }) => void | Promise<void>;
 }
+
+interface RoomEventEnvelope {
+  event_id: number;
+  room_id: string;
+  timestamp: string;
+  payload: unknown;
+}
+
+const getLastEventIdStorageKey = (roomId: string) => `ws_last_event_id_${roomId}`;
+
+const loadLastEventId = (roomId: string): number => {
+  if (typeof window === "undefined" || !roomId) return 0;
+  try {
+    const raw = sessionStorage.getItem(getLastEventIdStorageKey(roomId));
+    if (!raw) return 0;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+  } catch {
+    return 0;
+  }
+};
+
+const persistLastEventId = (roomId: string, eventId: number) => {
+  if (typeof window === "undefined" || !roomId) return;
+  try {
+    sessionStorage.setItem(getLastEventIdStorageKey(roomId), String(eventId));
+  } catch {
+    // ignore storage errors
+  }
+};
+
+const isRoomEventEnvelope = (value: unknown): value is RoomEventEnvelope => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<RoomEventEnvelope>;
+  return (
+    typeof candidate.event_id === "number" &&
+    typeof candidate.room_id === "string" &&
+    typeof candidate.timestamp === "string" &&
+    "payload" in candidate
+  );
+};
 
 export const useGameWebSocket = (
   roomId: string,
-  addServerMessage: (message: ChatMessage) => void, // サーバー側メッセージを追加する関数
+  addServerMessage: (message: ChatMessage) => void,
   username?: string,
   options?: UseGameWebSocketOptions,
 ) => {
-  const { onReconnect } = options ?? {};
+  const { onReconnect, onGapDetected } = options ?? {};
   const websocketRef = useRef<WebSocket | null>(null);
   const [websocketStatus, setWebsocketStatus] = useState<WebSocketStatus>("disconnected");
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
@@ -23,11 +68,21 @@ export const useGameWebSocket = (
   const manualDisconnectRef = useRef(false);
   const hasConnectedOnceRef = useRef(false);
   const onReconnectRef = useRef<UseGameWebSocketOptions["onReconnect"]>(onReconnect);
+  const onGapDetectedRef = useRef<UseGameWebSocketOptions["onGapDetected"]>(onGapDetected);
   const connectWebSocketRef = useRef<() => void>(() => undefined);
+  const lastEventIdRef = useRef(0);
 
   useEffect(() => {
     onReconnectRef.current = onReconnect;
   }, [onReconnect]);
+
+  useEffect(() => {
+    onGapDetectedRef.current = onGapDetected;
+  }, [onGapDetected]);
+
+  useEffect(() => {
+    lastEventIdRef.current = loadLastEventId(roomId);
+  }, [roomId]);
 
   const wsUrl = useMemo(
     () => `${process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8080/api"}/room/${roomId}/ws`,
@@ -63,20 +118,61 @@ export const useGameWebSocket = (
 
   const handleSocketMessage = useCallback(
     (rawData: string) => {
-      let data: any;
+      let parsed: unknown;
       try {
-        data = JSON.parse(rawData);
+        parsed = JSON.parse(rawData);
       } catch (error) {
         console.error("Failed to parse WebSocket message:", error);
         return;
       }
 
-      if (!data || typeof data !== "object") {
+      let messageData = parsed;
+      let sourceEventId: number | undefined;
+      let sourceEventTimestamp: string | undefined;
+
+      if (isRoomEventEnvelope(parsed)) {
+        const incomingEventId = parsed.event_id;
+        const lastEventId = lastEventIdRef.current;
+
+        if (incomingEventId <= lastEventId) {
+          return;
+        }
+
+        if (lastEventId > 0 && incomingEventId > lastEventId + 1) {
+          const detail = {
+            expectedEventId: lastEventId + 1,
+            receivedEventId: incomingEventId,
+          };
+
+          window.dispatchEvent(new CustomEvent("wsEventGapDetected", { detail }));
+
+          if (onGapDetectedRef.current) {
+            void Promise.resolve(onGapDetectedRef.current(detail)).catch(error => {
+              console.error("Failed to recover after WebSocket event gap:", error);
+            });
+          } else if (onReconnectRef.current) {
+            void Promise.resolve(onReconnectRef.current()).catch(error => {
+              console.error("Failed to recover after WebSocket event gap:", error);
+            });
+          }
+        }
+
+        lastEventIdRef.current = incomingEventId;
+        persistLastEventId(roomId, incomingEventId);
+
+        sourceEventId = incomingEventId;
+        sourceEventTimestamp = parsed.timestamp;
+        messageData = parsed.payload;
+      }
+
+      if (!messageData || typeof messageData !== "object") {
         return;
       }
 
-      // フェーズ変更通知の場合
-      if (data.message_type === "phase_change") {
+      const data = messageData as Record<string, unknown>;
+      const messageType = data.message_type;
+
+      if (messageType === "phase_change") {
         window.dispatchEvent(
           new CustomEvent("phaseChangeNotification", {
             detail: {
@@ -89,8 +185,7 @@ export const useGameWebSocket = (
         return;
       }
 
-      // コミットメント準備完了通知の場合
-      if (data.message_type === "commitments_ready") {
+      if (messageType === "commitments_ready") {
         window.dispatchEvent(
           new CustomEvent("commitmentsReadyNotification", {
             detail: {
@@ -104,8 +199,7 @@ export const useGameWebSocket = (
         return;
       }
 
-      // 計算結果通知の場合
-      if (data.message_type === "computation_result") {
+      if (messageType === "computation_result") {
         window.dispatchEvent(
           new CustomEvent("computationResultNotification", {
             detail: {
@@ -120,8 +214,37 @@ export const useGameWebSocket = (
         return;
       }
 
-      // ゲームリセット通知の場合
-      if (data.message_type === "game_reset") {
+      if (messageType === "proof_job_status") {
+        window.dispatchEvent(
+          new CustomEvent("proofJobStatusNotification", {
+            detail: {
+              roomId: data.room_id,
+              batchId: data.batch_id,
+              state: data.state,
+              attemptCount: data.attempt_count,
+              lastError: data.last_error,
+              jobNodeStatus: data.job_node_status,
+              updatedAt: data.updated_at,
+            },
+          }),
+        );
+        return;
+      }
+
+      if (messageType === "room_state_changed") {
+        window.dispatchEvent(
+          new CustomEvent("roomStateChangedNotification", {
+            detail: {
+              roomId: data.room_id,
+              reason: data.reason,
+              timestamp: data.timestamp,
+            },
+          }),
+        );
+        return;
+      }
+
+      if (messageType === "game_reset") {
         window.dispatchEvent(
           new CustomEvent("gameResetNotification", {
             detail: {
@@ -133,22 +256,29 @@ export const useGameWebSocket = (
         return;
       }
 
-      // 通常のチャットメッセージ
       if (typeof data.player_name !== "string" || typeof data.content !== "string") {
         return;
       }
 
-      const fullMessage: WebSocketMessage = data;
+      const fullMessage = data as unknown as WebSocketMessage;
       addServerMessage({
-        id: typeof fullMessage.player_id === "string" ? fullMessage.player_id : "Server",
+        id:
+          sourceEventId !== undefined
+            ? `event-${sourceEventId}`
+            : typeof fullMessage.player_id === "string"
+              ? fullMessage.player_id
+              : "Server",
         sender: fullMessage.player_name,
         message: fullMessage.content,
-        timestamp: typeof fullMessage.timestamp === "string" ? fullMessage.timestamp : new Date().toISOString(),
+        timestamp:
+          typeof fullMessage.timestamp === "string"
+            ? fullMessage.timestamp
+            : sourceEventTimestamp || new Date().toISOString(),
         type: "normal",
         source: "server",
       });
     },
-    [addServerMessage],
+    [addServerMessage, roomId],
   );
 
   const connectWebSocket = useCallback(() => {
@@ -163,7 +293,10 @@ export const useGameWebSocket = (
     manualDisconnectRef.current = false;
     setWebsocketStatus(reconnectAttemptRef.current > 0 ? "reconnecting" : "connecting");
 
-    const ws = new WebSocket(wsUrl);
+    const lastEventId = lastEventIdRef.current;
+    const resumeWsUrl = lastEventId > 0 ? `${wsUrl}?last_event_id=${encodeURIComponent(String(lastEventId))}` : wsUrl;
+
+    const ws = new WebSocket(resumeWsUrl);
     websocketRef.current = ws;
 
     ws.onopen = () => {
@@ -245,12 +378,13 @@ export const useGameWebSocket = (
     setReconnectAttempt(0);
     hasConnectedOnceRef.current = false;
     manualDisconnectRef.current = false;
+    lastEventIdRef.current = loadLastEventId(roomId);
     connectWebSocket();
 
     return () => {
       disconnectWebSocket();
     };
-  }, [connectWebSocket, disconnectWebSocket]);
+  }, [connectWebSocket, disconnectWebSocket, roomId]);
 
   useEffect(() => {
     const tryReconnectNow = () => {

--- a/packages/nextjs/types/game.ts
+++ b/packages/nextjs/types/game.ts
@@ -31,6 +31,7 @@ export interface CryptoParameters {
 export interface GameInfo {
   room_id: string;
   phase: "Waiting" | "Night" | "DivinationProcessing" | "Discussion" | "Voting" | "Result" | "Finished";
+  day_count?: number;
   phase_started_at?: string;
   players: Player[];
   playerRole: Role;

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -136,7 +136,7 @@ pub struct ChangeRoleRequest {
     pub new_role: String,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProverInfo {
     pub user_id: String,
     pub prover_count: usize,
@@ -147,7 +147,7 @@ pub struct ProverInfo {
     pub public_key: Option<String>, // Curve25519公開鍵（Base64エンコード）
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "proof_type", content = "data")]
 pub enum ClientRequestType {
     Divination(ProverInfo),
@@ -230,7 +230,7 @@ pub struct BatchKey {
     pub circuit_profile: CircuitProfileKey,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchRequest {
     pub batch_id: String,
     pub requests: Vec<ClientRequestType>,
@@ -691,6 +691,16 @@ impl Game {
     }
 
     pub async fn apply_proof_result(&mut self, app_state: &crate::state::AppState) {
+        self.process_current_batch(app_state).await;
+    }
+
+    pub async fn apply_proof_result_for_batch(
+        &mut self,
+        app_state: &crate::state::AppState,
+        _batch_key: &BatchKey,
+        batch_request: BatchRequest,
+    ) {
+        self.batch_request = batch_request;
         self.process_current_batch(app_state).await;
     }
 

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -142,6 +142,8 @@ pub struct ProverInfo {
     pub prover_count: usize,
     pub encrypted_data: String,
     #[serde(default)]
+    pub is_dummy: bool,
+    #[serde(default)]
     pub public_key: Option<String>, // Curve25519公開鍵（Base64エンコード）
 }
 
@@ -183,6 +185,13 @@ impl ClientRequestType {
             | ClientRequestType::WinningJudge(info)
             | ClientRequestType::RoleAssignment(info)
             | ClientRequestType::KeyPublicize(info) => info.public_key.as_deref(),
+        }
+    }
+
+    pub(crate) fn is_dummy(&self) -> bool {
+        match self {
+            ClientRequestType::Divination(info) => info.is_dummy,
+            _ => false,
         }
     }
 
@@ -644,11 +653,16 @@ impl Game {
             ));
         }
 
-        if !batch
+        if let Some(existing_index) = batch
             .requests
             .iter()
-            .any(|r| r.get_user_id() == request.get_user_id())
+            .position(|r| r.get_user_id() == request.get_user_id())
         {
+            let should_replace = batch.requests[existing_index].is_dummy() && !request.is_dummy();
+            if should_replace {
+                batch.requests[existing_index] = request;
+            }
+        } else {
             batch.requests.push(request);
         }
 

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -7,8 +7,6 @@ use crate::{
         chat::{ChatMessage, ChatMessageType},
         role::Role,
     },
-    services::zk_proof::check_status_with_retry,
-    utils::config::CONFIG,
 };
 
 use super::player::Player;
@@ -20,11 +18,9 @@ use base64;
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use mpc_algebra_wasm::*;
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use zk_mpc::circuits::{ElGamalLocalOrMPC, LocalOrMPC};
-use zk_mpc_node::{ProofOutputType, ProofRequest, UserPublicKey};
 
 #[derive(Serialize, Deserialize, Derivative, Clone)]
 #[derivative(Debug)]
@@ -42,6 +38,9 @@ pub struct Game {
     pub chat_log: super::chat::ChatLog,
     #[derivative(Debug = "ignore")]
     pub batch_request: BatchRequest,
+    #[derivative(Debug = "ignore")]
+    #[serde(skip)]
+    pub active_batches: HashMap<BatchKey, BatchRequest>,
     pub computation_results: ComputationResults,
     pub started_at: Option<DateTime<Utc>>,
     pub phase_started_at: DateTime<Utc>,
@@ -91,7 +90,7 @@ pub struct DivinationComputationResult {
         <<Fr as ElGamalLocalOrMPC<Fr>>::ElGamalScheme as AsymmetricEncryptionScheme>::Ciphertext,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum GamePhase {
     Waiting,              // ゲーム開始前
     Night,                // 夜フェーズ
@@ -157,7 +156,7 @@ pub enum ClientRequestType {
 }
 
 impl ClientRequestType {
-    fn get_prover_count(&self) -> usize {
+    pub(crate) fn get_prover_count(&self) -> usize {
         match self {
             ClientRequestType::Divination(info)
             | ClientRequestType::AnonymousVoting(info)
@@ -167,7 +166,7 @@ impl ClientRequestType {
         }
     }
 
-    fn get_user_id(&self) -> &str {
+    pub(crate) fn get_user_id(&self) -> &str {
         match self {
             ClientRequestType::Divination(info)
             | ClientRequestType::AnonymousVoting(info)
@@ -177,7 +176,7 @@ impl ClientRequestType {
         }
     }
 
-    fn get_public_key(&self) -> Option<&str> {
+    pub(crate) fn get_public_key(&self) -> Option<&str> {
         match self {
             ClientRequestType::Divination(info)
             | ClientRequestType::AnonymousVoting(info)
@@ -186,28 +185,65 @@ impl ClientRequestType {
             | ClientRequestType::KeyPublicize(info) => info.public_key.as_deref(),
         }
     }
+
+    pub fn get_proof_type(&self) -> ProofTypeKey {
+        match self {
+            ClientRequestType::Divination(_) => ProofTypeKey::Divination,
+            ClientRequestType::AnonymousVoting(_) => ProofTypeKey::AnonymousVoting,
+            ClientRequestType::WinningJudge(_) => ProofTypeKey::WinningJudge,
+            ClientRequestType::RoleAssignment(_) => ProofTypeKey::RoleAssignment,
+            ClientRequestType::KeyPublicize(_) => ProofTypeKey::KeyPublicize,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum ProofTypeKey {
+    RoleAssignment,
+    Divination,
+    AnonymousVoting,
+    WinningJudge,
+    KeyPublicize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CircuitProfileKey {
+    pub player_count: usize,
+    pub werewolf_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BatchKey {
+    pub room_id: String,
+    pub phase: GamePhase,
+    pub day_count: u32,
+    pub proof_type: ProofTypeKey,
+    pub circuit_profile: CircuitProfileKey,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct BatchRequest {
     pub batch_id: String,
     pub requests: Vec<ClientRequestType>,
+    #[serde(default)]
+    pub expected_prover_count: usize,
     pub status: BatchStatus,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
 impl BatchRequest {
-    pub fn new() -> Self {
+    pub fn new(expected_prover_count: usize) -> Self {
         BatchRequest {
             batch_id: uuid::Uuid::new_v4().to_string(),
             requests: Vec::new(),
+            expected_prover_count,
             status: BatchStatus::Collecting,
             created_at: chrono::Utc::now(),
         }
     }
 }
 
-fn try_convert_to_identifier(
+pub(crate) fn try_convert_to_identifier(
     requests: Vec<ClientRequestType>,
 ) -> Result<CircuitEncryptedInputIdentifier, String> {
     use ClientRequestType::*;
@@ -218,13 +254,14 @@ fn try_convert_to_identifier(
                     .into_iter()
                     .map(|r| {
                         if let Divination(d) = r {
-                            serde_json::from_str(&d.encrypted_data)
-                                .expect("Failed to deserialize DivinationOutput")
+                            serde_json::from_str(&d.encrypted_data).map_err(|e| {
+                                format!("Failed to deserialize DivinationOutput: {}", e)
+                            })
                         } else {
-                            unreachable!()
+                            Err("Unexpected request type in Divination batch".to_string())
                         }
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, _>>()?;
                 Ok(CircuitEncryptedInputIdentifier::Divination(items))
             }
             AnonymousVoting(_) if rest.iter().all(|r| matches!(r, AnonymousVoting(_))) => {
@@ -232,13 +269,14 @@ fn try_convert_to_identifier(
                     .into_iter()
                     .map(|r| {
                         if let AnonymousVoting(d) = r {
-                            serde_json::from_str(&d.encrypted_data)
-                                .expect("Failed to deserialize AnonymousVotingOutput")
+                            serde_json::from_str(&d.encrypted_data).map_err(|e| {
+                                format!("Failed to deserialize AnonymousVotingOutput: {}", e)
+                            })
                         } else {
-                            unreachable!()
+                            Err("Unexpected request type in AnonymousVoting batch".to_string())
                         }
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, _>>()?;
                 Ok(CircuitEncryptedInputIdentifier::AnonymousVoting(items))
             }
             WinningJudge(_) if rest.iter().all(|r| matches!(r, WinningJudge(_))) => {
@@ -246,13 +284,14 @@ fn try_convert_to_identifier(
                     .into_iter()
                     .map(|r| {
                         if let WinningJudge(d) = r {
-                            serde_json::from_str(&d.encrypted_data)
-                                .expect("Failed to deserialize WinningJudgeOutput")
+                            serde_json::from_str(&d.encrypted_data).map_err(|e| {
+                                format!("Failed to deserialize WinningJudgeOutput: {}", e)
+                            })
                         } else {
-                            unreachable!()
+                            Err("Unexpected request type in WinningJudge batch".to_string())
                         }
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, _>>()?;
                 Ok(CircuitEncryptedInputIdentifier::WinningJudge(items))
             }
             RoleAssignment(_) if rest.iter().all(|r| matches!(r, RoleAssignment(_))) => {
@@ -260,13 +299,14 @@ fn try_convert_to_identifier(
                     .into_iter()
                     .map(|r| {
                         if let RoleAssignment(d) = r {
-                            serde_json::from_str(&d.encrypted_data)
-                                .expect("Failed to deserialize RoleAssignmentOutput")
+                            serde_json::from_str(&d.encrypted_data).map_err(|e| {
+                                format!("Failed to deserialize RoleAssignmentOutput: {}", e)
+                            })
                         } else {
-                            unreachable!()
+                            Err("Unexpected request type in RoleAssignment batch".to_string())
                         }
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, _>>()?;
                 Ok(CircuitEncryptedInputIdentifier::RoleAssignment(items))
             }
             KeyPublicize(_) if rest.iter().all(|r| matches!(r, KeyPublicize(_))) => {
@@ -274,13 +314,14 @@ fn try_convert_to_identifier(
                     .into_iter()
                     .map(|r| {
                         if let KeyPublicize(d) = r {
-                            serde_json::from_str(&d.encrypted_data)
-                                .expect("Failed to deserialize KeyPublicizeOutput")
+                            serde_json::from_str(&d.encrypted_data).map_err(|e| {
+                                format!("Failed to deserialize KeyPublicizeOutput: {}", e)
+                            })
                         } else {
-                            unreachable!()
+                            Err("Unexpected request type in KeyPublicize batch".to_string())
                         }
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, _>>()?;
                 Ok(CircuitEncryptedInputIdentifier::KeyPublicize(items))
             }
             _ => Err("ClientRequestType variants are mixed; cannot convert".to_string()),
@@ -295,6 +336,15 @@ pub enum BatchStatus {
     Processing,
     Completed,
     Failed,
+}
+
+pub struct BatchEnqueueResult {
+    pub batch_id: String,
+    pub should_process: bool,
+}
+
+pub enum BatchEnqueueError {
+    Conflict(String),
 }
 
 impl Game {
@@ -316,7 +366,8 @@ impl Game {
             vote_results: HashMap::new(),
             crypto_parameters: None,
             chat_log: super::chat::ChatLog::new(room_id),
-            batch_request: BatchRequest::new(),
+            batch_request: BatchRequest::new(0),
+            active_batches: HashMap::new(),
             computation_results: ComputationResults::default(),
             started_at: Some(Utc::now()),
             phase_started_at: Utc::now(),
@@ -367,6 +418,12 @@ impl Game {
     // より厳密な占い可能性チェック
     pub fn can_perform_divination(&self) -> bool {
         self.phase == GamePhase::Night && !self.has_divination_for_current_phase()
+    }
+
+    pub fn has_pending_or_processing_batches(&self) -> bool {
+        self.batch_request.status == BatchStatus::Processing
+            || !self.batch_request.requests.is_empty()
+            || !self.active_batches.is_empty()
     }
 
     // DivinationProcessing フェーズから Discussion フェーズへの遷移を管理
@@ -541,167 +598,115 @@ impl Game {
         ));
     }
 
+    pub fn build_batch_key(&self, request: &ClientRequestType) -> BatchKey {
+        BatchKey {
+            room_id: self.room_id.clone(),
+            phase: self.phase.clone(),
+            day_count: self.day_count,
+            proof_type: request.get_proof_type(),
+            circuit_profile: CircuitProfileKey {
+                player_count: self.grouping_parameter.get_num_players(),
+                werewolf_count: self.grouping_parameter.get_werewolf_count(),
+            },
+        }
+    }
+
+    pub fn add_request_to_batch(
+        &mut self,
+        request: ClientRequestType,
+    ) -> Result<BatchEnqueueResult, BatchEnqueueError> {
+        let expected_prover_count = request.get_prover_count();
+        if expected_prover_count == 0 {
+            return Err(BatchEnqueueError::Conflict(
+                "prover_count must be greater than zero".to_string(),
+            ));
+        }
+
+        let batch_key = self.build_batch_key(&request);
+        let batch = self
+            .active_batches
+            .entry(batch_key.clone())
+            .or_insert_with(|| BatchRequest::new(expected_prover_count));
+
+        if batch.expected_prover_count != expected_prover_count {
+            return Err(BatchEnqueueError::Conflict(
+                "conflicting prover_count for the same batch key".to_string(),
+            ));
+        }
+
+        if batch
+            .requests
+            .iter()
+            .any(|r| r.get_proof_type() != request.get_proof_type())
+        {
+            return Err(BatchEnqueueError::Conflict(
+                "proof type mismatch in existing batch".to_string(),
+            ));
+        }
+
+        if !batch
+            .requests
+            .iter()
+            .any(|r| r.get_user_id() == request.get_user_id())
+        {
+            batch.requests.push(request);
+        }
+
+        let batch_id = batch.batch_id.clone();
+        let should_process = batch.requests.len() >= batch.expected_prover_count;
+
+        if should_process {
+            if let Some(mut ready_batch) = self.active_batches.remove(&batch_key) {
+                ready_batch.status = BatchStatus::Collecting;
+                self.batch_request = ready_batch;
+            }
+        }
+
+        Ok(BatchEnqueueResult {
+            batch_id,
+            should_process,
+        })
+    }
+
     pub async fn add_request(
         &mut self,
         request: ClientRequestType,
         app_state: &crate::state::AppState,
     ) -> String {
-        // let mut batch_request = &self.batch_request;
-        let size_limit = request.get_prover_count();
-
-        if !self
-            .batch_request
-            .requests
-            .iter()
-            .any(|r| r.get_user_id() == request.get_user_id())
-        {
-            self.batch_request.requests.push(request);
-
-            // バッチが満杯になったら処理を開始
-            if self.batch_request.requests.len() >= size_limit {
-                let batch_id = self.batch_request.batch_id.clone();
-
-                // let mut service = self.clone();
-
-                // TODO: 非同期でバッチ処理を開始
-                // tokio::spawn(async move {
-                // let mut games = game.lock().await;
-                // if let Some(game) = games.get_mut(room_id) {
-                //     // ゲームの状態を更新する処理
-                //     // ...
-                // }
-
-                self.process_batch(app_state).await;
-                // });
-
-                // 新しいバッチを作成
-                self.batch_request = BatchRequest::new();
-
-                batch_id
-            } else {
-                self.batch_request.batch_id.clone()
+        match self.add_request_to_batch(request) {
+            Ok(result) => {
+                if result.should_process {
+                    self.process_current_batch(app_state).await;
+                }
+                result.batch_id
             }
-        } else {
-            self.batch_request.batch_id.clone()
+            Err(BatchEnqueueError::Conflict(_)) => self.batch_request.batch_id.clone(),
         }
+    }
+
+    pub async fn process_current_batch(&mut self, app_state: &crate::state::AppState) {
+        if self.batch_request.requests.is_empty() {
+            return;
+        }
+
+        self.process_batch(app_state).await;
+        self.batch_request = BatchRequest::new(0);
     }
 
     async fn process_batch(&mut self, app_state: &crate::state::AppState) {
         self.batch_request.status = BatchStatus::Processing;
 
-        // batch_request.requestsをuser_idでソート（数値文字列として）
-        self.batch_request.requests.sort_by(|a, b| {
-            let a_user_id = a.get_user_id().parse::<u32>().unwrap_or(u32::MAX);
-            let b_user_id = b.get_user_id().parse::<u32>().unwrap_or(u32::MAX);
-            a_user_id.cmp(&b_user_id)
-        });
-
-        // requsets: Vec<ClientRequestType>をCircuitEncryptedInputIdentifierに変換
-        let identifier = try_convert_to_identifier(self.batch_request.requests.clone())
-            .map_err(|e| {
-                self.batch_request.status = BatchStatus::Failed;
-                e
-            })
-            .unwrap();
-
-        let client = Client::new();
-
-        let mut responses = Vec::new();
-
-        // RoleAssignmentの場合、プレイヤー公開鍵を収集
-        let output_type = match &identifier {
-            CircuitEncryptedInputIdentifier::RoleAssignment(_) => {
-                let mut player_pubkeys = Vec::new();
-                for request in &self.batch_request.requests {
-                    if let Some(pubkey) = request.get_public_key() {
-                        player_pubkeys.push(UserPublicKey {
-                            user_id: request.get_user_id().to_string(),
-                            public_key: pubkey.to_string(),
-                        });
-                    } else {
-                        println!(
-                            "Warning: Request from user {} missing public_key",
-                            request.get_user_id()
-                        );
-                    }
-                }
-
-                if player_pubkeys.is_empty() {
-                    println!("ERROR: No player public keys found for RoleAssignment");
-                    self.batch_request.status = BatchStatus::Failed;
-                    self.chat_log.add_system_message(
-                        "Failed to process role assignment: No player public keys".to_string(),
-                    );
-                    return;
-                }
-
-                println!(
-                    "Collected {} player public keys for RoleAssignment",
-                    player_pubkeys.len()
-                );
-                ProofOutputType::PrivateToPublic(player_pubkeys)
-            }
-            _ => ProofOutputType::Public,
+        let proof_execution = match crate::services::zk_proof::take_precomputed_batch_result(
+            &self.batch_request.batch_id,
+        )
+        .await
+        {
+            Some(result) => result,
+            None => crate::services::zk_proof::execute_batch_request(&self.batch_request).await,
         };
 
-        let req_to_node = ProofRequest {
-            proof_id: self.batch_request.batch_id.clone(),
-            circuit_type: identifier.clone(),
-            output_type,
-        };
-
-        // identifierをzk-mpc-nodeに送信するなどの処理を行う
-        let node_urls = CONFIG.zk_mpc_node_urls();
-        println!("Sending proof request to ZK-MPC nodes: {:?}", node_urls);
-
-        for url in &node_urls {
-            println!("Sending request to {}", url);
-            let response = client
-                .post(url)
-                .json(&req_to_node)
-                .send()
-                .await
-                .map_err(|e| {
-                    let error_msg = format!("Failed to send request to {}: {}", url, e);
-                    println!("ERROR: {}", error_msg);
-                    error_msg
-                });
-            responses.push(response);
-        }
-
-        // レスポンスを処理
-        for (url, response) in node_urls.iter().zip(responses) {
-            match response {
-                Ok(resp) => match resp.json::<serde_json::Value>().await {
-                    Ok(response_body) => {
-                        println!("Response from {}: {:?}", url, response_body);
-                    }
-                    Err(e) => {
-                        println!("ERROR: Failed to parse JSON response from {}: {}", url, e);
-                        self.batch_request.status = BatchStatus::Failed;
-                        self.chat_log.add_system_message(format!(
-                            "Failed to process proof: Invalid response from ZK node at {}",
-                            url
-                        ));
-                        return;
-                    }
-                },
-                Err(e) => {
-                    println!("ERROR: Failed to get response from {}: {}", url, e);
-                    self.batch_request.status = BatchStatus::Failed;
-                    self.chat_log.add_system_message(format!(
-                        "Failed to connect to ZK node at {}: {}",
-                        url, e
-                    ));
-                    return;
-                }
-            }
-        }
-
-        // 3. 結果の確認（非同期で実行）
-        // tokio::spawn(async move {
-        match check_status_with_retry(&self.batch_request.batch_id).await {
-            Ok((true, Some(output))) => {
+        match proof_execution {
+            Ok((identifier, output)) => {
                 println!(
                     "Proof ID {:?} is ready with output: {:?}",
                     self.batch_request.batch_id, output
@@ -892,7 +897,14 @@ impl Game {
                         }
 
                         // 全プレイヤーに占い結果を通知
-                        let latest_divination = self.computation_results.divination.last().unwrap();
+                        let Some(latest_divination) = self.computation_results.divination.last()
+                        else {
+                            self.batch_request.status = BatchStatus::Failed;
+                            self.chat_log.add_system_message(
+                                "Divination result was not persisted correctly.".to_string(),
+                            );
+                            return;
+                        };
                         let result_data = serde_json::json!({
                             "ciphertext": serde_json::to_value(&latest_divination.result.ciphertext).unwrap_or_default(),
                             "phase": latest_divination.phase,
@@ -1293,9 +1305,14 @@ impl Game {
                             }
                         };
 
+                        let pub_key_x_json = serde_json::to_string(&pub_key_x)
+                            .unwrap_or_else(|_| "\"serialization_error\"".to_string());
+                        let pub_key_y_json = serde_json::to_string(&pub_key_y)
+                            .unwrap_or_else(|_| "\"serialization_error\"".to_string());
+
                         println!("Fortune teller public key received from KeyPublicize MPC:");
-                        println!("  X: {}", serde_json::to_string(&pub_key_x).unwrap());
-                        println!("  Y: {}", serde_json::to_string(&pub_key_y).unwrap());
+                        println!("  X: {}", pub_key_x_json);
+                        println!("  Y: {}", pub_key_y_json);
 
                         // EdwardsProjectiveに変換してcrypto_parametersに保存
 
@@ -1315,8 +1332,8 @@ impl Game {
                         // 全プレイヤーに占い公開鍵を配信（フロントエンド互換形式）
                         let key_data = serde_json::json!({
                             "divination_public_key": {
-                                "x": serde_json::to_string(&pub_key_x).unwrap(),
-                                "y": serde_json::to_string(&pub_key_y).unwrap(),
+                                "x": pub_key_x_json,
+                                "y": pub_key_y_json,
                                 "_params": null
                             },
                             "status": "completed"
@@ -1343,13 +1360,17 @@ impl Game {
 
                 self.batch_request.status = BatchStatus::Completed;
             }
-            _ => {
+            Err(error) => {
                 // 失敗時の処理
-                println!("Proof ID {:?} is failed", self.batch_request.batch_id);
+                println!(
+                    "Proof ID {:?} is failed: {}",
+                    self.batch_request.batch_id, error
+                );
                 self.batch_request.status = BatchStatus::Failed;
+                self.chat_log
+                    .add_system_message(format!("Failed to process proof: {}", error));
             }
         }
-        // });
     }
 }
 

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -352,6 +352,7 @@ pub struct BatchEnqueueResult {
     pub should_process: bool,
 }
 
+#[derive(Debug)]
 pub enum BatchEnqueueError {
     Conflict(String),
 }
@@ -682,20 +683,15 @@ impl Game {
         })
     }
 
-    pub async fn add_request(
+    pub fn add_request(
         &mut self,
         request: ClientRequestType,
-        app_state: &crate::state::AppState,
-    ) -> String {
-        match self.add_request_to_batch(request) {
-            Ok(result) => {
-                if result.should_process {
-                    self.process_current_batch(app_state).await;
-                }
-                result.batch_id
-            }
-            Err(BatchEnqueueError::Conflict(_)) => self.batch_request.batch_id.clone(),
-        }
+    ) -> Result<BatchEnqueueResult, BatchEnqueueError> {
+        self.add_request_to_batch(request)
+    }
+
+    pub async fn apply_proof_result(&mut self, app_state: &crate::state::AppState) {
+        self.process_current_batch(app_state).await;
     }
 
     pub async fn process_current_batch(&mut self, app_state: &crate::state::AppState) {

--- a/packages/server/src/routes/game.rs
+++ b/packages/server/src/routes/game.rs
@@ -67,8 +67,19 @@ pub async fn start_game(
     State(state): State<AppState>,
     Path(room_id): Path<String>,
 ) -> impl IntoResponse {
-    match game_service::start_game(state, &room_id).await {
-        Ok(message) => (StatusCode::OK, Json(message)),
+    match game_service::start_game(state.clone(), &room_id).await {
+        Ok(message) => {
+            if let Err(e) = state
+                .broadcast_room_state_changed(&room_id, "game_started")
+                .await
+            {
+                tracing::warn!(
+                    "Failed to broadcast room_state_changed on game start: {}",
+                    e
+                );
+            }
+            (StatusCode::OK, Json(message))
+        }
         Err(message) => (StatusCode::NOT_FOUND, Json(message)),
     }
 }
@@ -90,8 +101,16 @@ async fn end_game_handler(
     State(state): State<AppState>,
     Path(room_id): Path<String>,
 ) -> impl IntoResponse {
-    match game_service::end_game(state, room_id).await {
-        Ok(message) => (StatusCode::OK, Json(message)),
+    match game_service::end_game(state.clone(), room_id.clone()).await {
+        Ok(message) => {
+            if let Err(e) = state
+                .broadcast_room_state_changed(&room_id, "game_ended")
+                .await
+            {
+                tracing::warn!("Failed to broadcast room_state_changed on game end: {}", e);
+            }
+            (StatusCode::OK, Json(message))
+        }
         Err(message) => (StatusCode::NOT_FOUND, Json(message)),
     }
 }
@@ -147,8 +166,19 @@ async fn advance_phase_handler(
     State(state): State<AppState>,
     Path(room_id): Path<String>,
 ) -> impl IntoResponse {
-    match game_service::advance_game_phase(state, &room_id).await {
-        Ok(message) => (StatusCode::OK, Json(message)),
+    match game_service::advance_game_phase(state.clone(), &room_id).await {
+        Ok(message) => {
+            if let Err(e) = state
+                .broadcast_room_state_changed(&room_id, "phase_advanced")
+                .await
+            {
+                tracing::warn!(
+                    "Failed to broadcast room_state_changed on phase advance: {}",
+                    e
+                );
+            }
+            (StatusCode::OK, Json(message))
+        }
         Err(message) => (StatusCode::BAD_REQUEST, Json(message)),
     }
 }

--- a/packages/server/src/routes/game.rs
+++ b/packages/server/src/routes/game.rs
@@ -113,7 +113,15 @@ pub async fn proof_handler(
 ) -> impl IntoResponse {
     match zk_proof::batch_proof_handling(state, &room_id, &request).await {
         Ok(batch_id) => (StatusCode::OK, Json(batch_id)),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(e)),
+        Err(zk_proof::ProofHandlingError::Conflict(message)) => {
+            (StatusCode::CONFLICT, Json(message))
+        }
+        Err(zk_proof::ProofHandlingError::Unprocessable(message)) => {
+            (StatusCode::UNPROCESSABLE_ENTITY, Json(message))
+        }
+        Err(zk_proof::ProofHandlingError::Internal(message)) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(message))
+        }
     }
 }
 
@@ -265,6 +273,8 @@ async fn reset_game_handler(
         reset_game.result = GameResult::InProgress;
 
         reset_game.day_count = 1;
+        reset_game.batch_request = BatchRequest::new(0);
+        reset_game.active_batches.clear();
 
         // computation_results をリセット
         reset_game.computation_results = ComputationResults::default();
@@ -322,7 +332,8 @@ async fn reset_batch_request_handler(
 
     if let Some(game) = games.get_mut(&room_id) {
         // バッチリクエストを新しいものに置き換え
-        game.batch_request = BatchRequest::new();
+        game.batch_request = BatchRequest::new(0);
+        game.active_batches.clear();
 
         // システムメッセージを追加
         game.chat_log

--- a/packages/server/src/routes/game.rs
+++ b/packages/server/src/routes/game.rs
@@ -47,6 +47,7 @@ pub fn routes(state: AppState) -> Router {
                     Router::new().route("/night-action", post(night_action_handler)),
                 )
                 .route("/proof", post(proof_handler))
+                .route("/proof/:batch_id/status", get(get_proof_job_status))
                 // 暗号パラメータとコミットメント管理
                 .route("/crypto-params", get(get_crypto_params))
                 .route("/commitment", post(submit_commitment))
@@ -122,6 +123,23 @@ pub async fn proof_handler(
         Err(zk_proof::ProofHandlingError::Internal(message)) => {
             (StatusCode::INTERNAL_SERVER_ERROR, Json(message))
         }
+    }
+}
+
+pub async fn get_proof_job_status(
+    State(state): State<AppState>,
+    Path((room_id, batch_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    match state.proof_job_service.get_status(&batch_id).await {
+        Some(status) if status.room_id == room_id => (StatusCode::OK, Json(json!(status))),
+        Some(_) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Proof job not found for this room" })),
+        ),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "Proof job not found" })),
+        ),
     }
 }
 

--- a/packages/server/src/routes/room.rs
+++ b/packages/server/src/routes/room.rs
@@ -109,8 +109,15 @@ pub async fn join_room(
         Err(_) => return (StatusCode::BAD_REQUEST, Json("User not found")),
     };
 
-    let success = room_service::join_room(state, &room_id, &player_id, &user.username).await;
+    let success =
+        room_service::join_room(state.clone(), &room_id, &player_id, &user.username).await;
     if success {
+        if let Err(e) = state
+            .broadcast_room_state_changed(&room_id, "player_joined")
+            .await
+        {
+            tracing::warn!("Failed to broadcast room_state_changed on join: {}", e);
+        }
         (StatusCode::OK, Json("Successfully joined room"))
     } else {
         (StatusCode::BAD_REQUEST, Json("Failed to join room"))
@@ -121,8 +128,16 @@ pub async fn leave_room(
     State(state): State<AppState>,
     Path((room_id, player_id)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    match room_service::leave_room(state, &room_id, &player_id).await {
-        Ok(message) => (StatusCode::OK, Json(message)),
+    match room_service::leave_room(state.clone(), &room_id, &player_id).await {
+        Ok(message) => {
+            if let Err(e) = state
+                .broadcast_room_state_changed(&room_id, "player_left")
+                .await
+            {
+                tracing::warn!("Failed to broadcast room_state_changed on leave: {}", e);
+            }
+            (StatusCode::OK, Json(message))
+        }
         Err(message) => (StatusCode::BAD_REQUEST, Json(message)),
     }
 }
@@ -141,8 +156,19 @@ pub async fn toggle_ready(
     State(state): State<AppState>,
     Path((room_id, player_id)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    match room_service::toggle_ready(state, &room_id, &player_id).await {
-        Ok(message) => (StatusCode::OK, Json(message)),
+    match room_service::toggle_ready(state.clone(), &room_id, &player_id).await {
+        Ok(message) => {
+            if let Err(e) = state
+                .broadcast_room_state_changed(&room_id, "ready_toggled")
+                .await
+            {
+                tracing::warn!(
+                    "Failed to broadcast room_state_changed on ready toggle: {}",
+                    e
+                );
+            }
+            (StatusCode::OK, Json(message))
+        }
         Err(e) => (StatusCode::BAD_REQUEST, Json(e)),
     }
 }

--- a/packages/server/src/services.rs
+++ b/packages/server/src/services.rs
@@ -1,5 +1,6 @@
 pub mod game_service;
 pub mod node_key;
+pub mod proof_job_service;
 pub mod room_service;
 pub mod user_service;
 pub mod zk_proof;

--- a/packages/server/src/services/game_service.rs
+++ b/packages/server/src/services/game_service.rs
@@ -1,7 +1,7 @@
 use crate::{
     blockchain::state_hash::{compute_game_id, compute_game_state_hash, is_evm_address},
     models::{
-        game::{BatchStatus, Game, GamePhase, NightAction, NightActionRequest},
+        game::{Game, GamePhase, NightAction, NightActionRequest},
         role::Role,
         room::{RoleConfig, RoomStatus, TimeConfig},
     },
@@ -211,7 +211,7 @@ pub async fn auto_advance_due_phases(state: AppState) {
                     return None;
                 }
 
-                if game.batch_request.status == BatchStatus::Processing {
+                if game.has_pending_or_processing_batches() {
                     return None;
                 }
 

--- a/packages/server/src/services/proof_job_service.rs
+++ b/packages/server/src/services/proof_job_service.rs
@@ -88,9 +88,9 @@ impl ProofJobService {
     }
 
     pub async fn enqueue_job(&self, app_state: AppState, job: ProofJob) -> Result<(), String> {
-        self.ensure_worker_started(app_state).await;
+        self.ensure_worker_started(app_state.clone()).await;
 
-        {
+        let initial_status_for_broadcast = {
             let mut statuses = self.statuses.lock().await;
             if let Some(existing) = statuses.get(&job.batch_request.batch_id) {
                 if matches!(existing.state.as_str(), "pending" | "running") {
@@ -100,9 +100,19 @@ impl ProofJobService {
                     ));
                 }
             }
-            statuses.insert(
-                job.batch_request.batch_id.clone(),
-                ProofJobStatus::new(&job),
+            let initial_status = ProofJobStatus::new(&job);
+            statuses.insert(job.batch_request.batch_id.clone(), initial_status.clone());
+            initial_status
+        };
+
+        if let Err(e) = app_state
+            .broadcast_proof_job_status(&job.room_id, &initial_status_for_broadcast)
+            .await
+        {
+            tracing::warn!(
+                "Failed to broadcast pending proof job status for room {}: {}",
+                job.room_id,
+                e
             );
         }
 
@@ -141,6 +151,8 @@ async fn process_job(
     job: ProofJob,
 ) {
     let batch_id = job.batch_request.batch_id.clone();
+    let room_id = job.room_id.clone();
+    let mut running_status_for_broadcast = None;
 
     {
         let mut status_map = statuses.lock().await;
@@ -152,6 +164,20 @@ async fn process_job(
                 node_status.state = "running".to_string();
                 node_status.attempt_count += 1;
             }
+            running_status_for_broadcast = Some(status.clone());
+        }
+    }
+
+    if let Some(status) = running_status_for_broadcast {
+        if let Err(e) = app_state
+            .broadcast_proof_job_status(&room_id, &status)
+            .await
+        {
+            tracing::warn!(
+                "Failed to broadcast running proof job status for room {}: {}",
+                room_id,
+                e
+            );
         }
     }
 
@@ -162,6 +188,7 @@ async fn process_job(
     crate::services::zk_proof::store_precomputed_batch_result(batch_id.clone(), execution_result)
         .await;
 
+    let mut final_status_for_broadcast = None;
     {
         let mut status_map = statuses.lock().await;
         if let Some(status) = status_map.get_mut(&batch_id) {
@@ -179,11 +206,25 @@ async fn process_job(
                 node_status.state = next_state.to_string();
                 node_status.last_error = execution_error.clone();
             }
+            final_status_for_broadcast = Some(status.clone());
+        }
+    }
+
+    if let Some(status) = final_status_for_broadcast {
+        if let Err(e) = app_state
+            .broadcast_proof_job_status(&room_id, &status)
+            .await
+        {
+            tracing::warn!(
+                "Failed to broadcast finalized proof job status for room {}: {}",
+                room_id,
+                e
+            );
         }
     }
 
     let mut games = app_state.games.lock().await;
-    let Some(game) = games.get_mut(&job.room_id) else {
+    let Some(game) = games.get_mut(&room_id) else {
         return;
     };
 

--- a/packages/server/src/services/proof_job_service.rs
+++ b/packages/server/src/services/proof_job_service.rs
@@ -1,0 +1,192 @@
+use crate::{
+    models::game::{BatchKey, BatchRequest},
+    state::AppState,
+    utils::config::CONFIG,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use tokio::sync::{mpsc, Mutex};
+
+#[derive(Debug, Clone)]
+pub struct ProofJob {
+    pub room_id: String,
+    pub batch_key: BatchKey,
+    pub batch_request: BatchRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeJobStatus {
+    pub state: String, // pending/running/completed/failed/timeout
+    pub attempt_count: u32,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofJobStatus {
+    pub state: String, // pending/running/completed/failed/timeout
+    pub batch_id: String,
+    pub room_id: String,
+    pub batch_key: BatchKey,
+    pub job_node_status: HashMap<String, NodeJobStatus>,
+    pub attempt_count: u32,
+    pub last_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ProofJobStatus {
+    fn new(job: &ProofJob) -> Self {
+        let mut job_node_status = HashMap::new();
+        for node_url in CONFIG.zk_mpc_node_urls() {
+            job_node_status.insert(
+                node_url,
+                NodeJobStatus {
+                    state: "pending".to_string(),
+                    attempt_count: 0,
+                    last_error: None,
+                },
+            );
+        }
+
+        Self {
+            state: "pending".to_string(),
+            batch_id: job.batch_request.batch_id.clone(),
+            room_id: job.room_id.clone(),
+            batch_key: job.batch_key.clone(),
+            job_node_status,
+            attempt_count: 0,
+            last_error: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+}
+
+pub struct ProofJobService {
+    sender: mpsc::Sender<ProofJob>,
+    receiver: Mutex<Option<mpsc::Receiver<ProofJob>>>,
+    statuses: Arc<Mutex<HashMap<String, ProofJobStatus>>>,
+    worker_started: AtomicBool,
+}
+
+impl ProofJobService {
+    pub fn new() -> Self {
+        let (sender, receiver) = mpsc::channel(256);
+        Self {
+            sender,
+            receiver: Mutex::new(Some(receiver)),
+            statuses: Arc::new(Mutex::new(HashMap::new())),
+            worker_started: AtomicBool::new(false),
+        }
+    }
+
+    pub async fn enqueue_job(&self, app_state: AppState, job: ProofJob) -> Result<(), String> {
+        self.ensure_worker_started(app_state).await;
+
+        {
+            let mut statuses = self.statuses.lock().await;
+            if let Some(existing) = statuses.get(&job.batch_request.batch_id) {
+                if matches!(existing.state.as_str(), "pending" | "running") {
+                    return Err(format!(
+                        "proof job {} is already {}",
+                        existing.batch_id, existing.state
+                    ));
+                }
+            }
+            statuses.insert(
+                job.batch_request.batch_id.clone(),
+                ProofJobStatus::new(&job),
+            );
+        }
+
+        self.sender.send(job).await.map_err(|e| e.to_string())
+    }
+
+    pub async fn get_status(&self, batch_id: &str) -> Option<ProofJobStatus> {
+        let statuses = self.statuses.lock().await;
+        statuses.get(batch_id).cloned()
+    }
+
+    async fn ensure_worker_started(&self, app_state: AppState) {
+        if self.worker_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let mut receiver_guard = self.receiver.lock().await;
+        let Some(mut receiver) = receiver_guard.take() else {
+            return;
+        };
+        drop(receiver_guard);
+
+        let statuses = self.statuses.clone();
+
+        tokio::spawn(async move {
+            while let Some(job) = receiver.recv().await {
+                process_job(statuses.clone(), app_state.clone(), job).await;
+            }
+        });
+    }
+}
+
+async fn process_job(
+    statuses: Arc<Mutex<HashMap<String, ProofJobStatus>>>,
+    app_state: AppState,
+    job: ProofJob,
+) {
+    let batch_id = job.batch_request.batch_id.clone();
+
+    {
+        let mut status_map = statuses.lock().await;
+        if let Some(status) = status_map.get_mut(&batch_id) {
+            status.state = "running".to_string();
+            status.attempt_count += 1;
+            status.updated_at = Utc::now();
+            for node_status in status.job_node_status.values_mut() {
+                node_status.state = "running".to_string();
+                node_status.attempt_count += 1;
+            }
+        }
+    }
+
+    let execution_result =
+        crate::services::zk_proof::execute_batch_request(&job.batch_request).await;
+    let execution_error = execution_result.as_ref().err().cloned();
+
+    crate::services::zk_proof::store_precomputed_batch_result(batch_id.clone(), execution_result)
+        .await;
+
+    {
+        let mut status_map = statuses.lock().await;
+        if let Some(status) = status_map.get_mut(&batch_id) {
+            status.updated_at = Utc::now();
+            status.last_error = execution_error.clone();
+
+            let next_state = match &execution_error {
+                None => "completed",
+                Some(err) if err.to_ascii_lowercase().contains("timeout") => "timeout",
+                Some(_) => "failed",
+            };
+            status.state = next_state.to_string();
+
+            for node_status in status.job_node_status.values_mut() {
+                node_status.state = next_state.to_string();
+                node_status.last_error = execution_error.clone();
+            }
+        }
+    }
+
+    let mut games = app_state.games.lock().await;
+    let Some(game) = games.get_mut(&job.room_id) else {
+        return;
+    };
+
+    game.apply_proof_result_for_batch(&app_state, &job.batch_key, job.batch_request)
+        .await;
+}

--- a/packages/server/src/services/zk_proof.rs
+++ b/packages/server/src/services/zk_proof.rs
@@ -326,11 +326,9 @@ pub async fn batch_proof_handling(
             .add_system_message(format!("{} has sent a proof request.", user_id));
 
         // バッチリクエストに追加
-        let enqueue_result =
-            game.add_request_to_batch(request.clone())
-                .map_err(|error| match error {
-                    BatchEnqueueError::Conflict(message) => ProofHandlingError::Conflict(message),
-                })?;
+        let enqueue_result = game.add_request(request.clone()).map_err(|error| match error {
+            BatchEnqueueError::Conflict(message) => ProofHandlingError::Conflict(message),
+        })?;
         (enqueue_result.batch_id, enqueue_result.should_process)
     };
 
@@ -359,7 +357,7 @@ pub async fn batch_proof_handling(
                 if game.batch_request.batch_id != batch_id {
                     return;
                 }
-                game.process_current_batch(&state_for_worker).await;
+                game.apply_proof_result(&state_for_worker).await;
             }
         });
     }

--- a/packages/server/src/services/zk_proof.rs
+++ b/packages/server/src/services/zk_proof.rs
@@ -15,6 +15,7 @@ use crate::{
         try_convert_to_identifier, BatchEnqueueError, BatchRequest, ClientRequestType, GamePhase,
         GameResult,
     },
+    services::proof_job_service::ProofJob,
     state::AppState,
 };
 
@@ -267,7 +268,7 @@ pub async fn batch_proof_handling(
     room_id: &str,
     request: &ClientRequestType,
 ) -> Result<String, ProofHandlingError> {
-    let (batch_id, should_process) = {
+    let (batch_id, proof_job) = {
         let mut games = state.games.lock().await;
         let game = match games.get_mut(room_id) {
             Some(game) => game,
@@ -326,40 +327,29 @@ pub async fn batch_proof_handling(
             .add_system_message(format!("{} has sent a proof request.", user_id));
 
         // バッチリクエストに追加
-        let enqueue_result = game.add_request(request.clone()).map_err(|error| match error {
-            BatchEnqueueError::Conflict(message) => ProofHandlingError::Conflict(message),
-        })?;
-        (enqueue_result.batch_id, enqueue_result.should_process)
+        let enqueue_result = game
+            .add_request(request.clone())
+            .map_err(|error| match error {
+                BatchEnqueueError::Conflict(message) => ProofHandlingError::Conflict(message),
+            })?;
+        let job = if enqueue_result.should_process {
+            Some(ProofJob {
+                room_id: room_id.to_string(),
+                batch_key: game.build_batch_key(request),
+                batch_request: game.batch_request.clone(),
+            })
+        } else {
+            None
+        };
+        (enqueue_result.batch_id, job)
     };
 
-    if should_process {
-        let state_for_worker = state.clone();
-        let room_id_for_worker = room_id.to_string();
-        tokio::spawn(async move {
-            let batch_snapshot = {
-                let mut games = state_for_worker.games.lock().await;
-                let Some(game) = games.get_mut(&room_id_for_worker) else {
-                    return;
-                };
-                if game.batch_request.requests.is_empty() {
-                    return;
-                }
-                game.batch_request.status = crate::models::game::BatchStatus::Processing;
-                game.batch_request.clone()
-            };
-
-            let batch_id = batch_snapshot.batch_id.clone();
-            let execution_result = execute_batch_request(&batch_snapshot).await;
-            store_precomputed_batch_result(batch_id.clone(), execution_result).await;
-
-            let mut games = state_for_worker.games.lock().await;
-            if let Some(game) = games.get_mut(&room_id_for_worker) {
-                if game.batch_request.batch_id != batch_id {
-                    return;
-                }
-                game.apply_proof_result(&state_for_worker).await;
-            }
-        });
+    if let Some(job) = proof_job {
+        state
+            .proof_job_service
+            .enqueue_job(state.clone(), job)
+            .await
+            .map_err(ProofHandlingError::Internal)?;
     }
 
     Ok(batch_id)
@@ -370,8 +360,9 @@ fn validate_phase_for_request(
     request: &ClientRequestType,
 ) -> Result<(), ProofHandlingError> {
     let is_valid = match request {
-        ClientRequestType::RoleAssignment(_)
-        | ClientRequestType::KeyPublicize(_) => matches!(phase, GamePhase::Night),
+        ClientRequestType::RoleAssignment(_) | ClientRequestType::KeyPublicize(_) => {
+            matches!(phase, GamePhase::Night)
+        }
         ClientRequestType::Divination(_) => matches!(phase, GamePhase::DivinationProcessing),
         ClientRequestType::AnonymousVoting(_) => matches!(phase, GamePhase::Voting),
         ClientRequestType::WinningJudge(_) => {

--- a/packages/server/src/services/zk_proof.rs
+++ b/packages/server/src/services/zk_proof.rs
@@ -374,9 +374,7 @@ fn validate_phase_for_request(
     let is_valid = match request {
         ClientRequestType::RoleAssignment(_)
         | ClientRequestType::KeyPublicize(_) => matches!(phase, GamePhase::Night),
-        ClientRequestType::Divination(_) => {
-            matches!(phase, GamePhase::Night | GamePhase::DivinationProcessing)
-        }
+        ClientRequestType::Divination(_) => matches!(phase, GamePhase::DivinationProcessing),
         ClientRequestType::AnonymousVoting(_) => matches!(phase, GamePhase::Voting),
         ClientRequestType::WinningJudge(_) => {
             matches!(

--- a/packages/server/src/services/zk_proof.rs
+++ b/packages/server/src/services/zk_proof.rs
@@ -1,16 +1,36 @@
 use crate::utils::config::CONFIG;
 use mpc_algebra_wasm::CircuitEncryptedInputIdentifier;
+use once_cell::sync::Lazy;
 use reqwest::Client;
+use std::collections::HashMap;
+use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 use zk_mpc_node::{
     models::{ProofOutput, ProofOutputType, ProofRequest, ProofResponse},
     ProofStatus,
 };
 
-use crate::{models::game::ClientRequestType, state::AppState};
+use crate::{
+    models::game::{
+        try_convert_to_identifier, BatchEnqueueError, BatchRequest, ClientRequestType, GamePhase,
+        GameResult,
+    },
+    state::AppState,
+};
 
 const MAX_RETRY_ATTEMPTS: u32 = 180;
 const RETRY_DELAY_SECS: u64 = 1;
+type BatchExecutionResult = Result<(CircuitEncryptedInputIdentifier, ProofOutput), String>;
+
+static PRECOMPUTED_BATCH_RESULTS: Lazy<Mutex<HashMap<String, BatchExecutionResult>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Debug)]
+pub enum ProofHandlingError {
+    Conflict(String),
+    Unprocessable(String),
+    Internal(String),
+}
 
 /// Sends a request to generate a zero-knowledge proof for the given circuit identifier and inputs.
 pub async fn request_proof_with_output(
@@ -48,7 +68,9 @@ pub async fn request_proof_with_output(
         .await
         .map_err(|e| e.to_string())?;
 
-    assert!(proof_response.success, "Failed to generate proof");
+    if !proof_response.success {
+        return Err("Failed to generate proof".to_string());
+    }
 
     Ok(proof_id)
 }
@@ -158,63 +180,221 @@ pub async fn check_status_with_retry(
     Ok((false, None))
 }
 
+pub async fn execute_batch_request(batch_request: &BatchRequest) -> BatchExecutionResult {
+    let mut sorted_requests = batch_request.requests.clone();
+    sorted_requests.sort_by(|a, b| {
+        let a_user_id = a.get_user_id().parse::<u32>().unwrap_or(u32::MAX);
+        let b_user_id = b.get_user_id().parse::<u32>().unwrap_or(u32::MAX);
+        a_user_id.cmp(&b_user_id)
+    });
+
+    let identifier = try_convert_to_identifier(sorted_requests.clone())?;
+
+    let output_type = match &identifier {
+        CircuitEncryptedInputIdentifier::RoleAssignment(_) => {
+            let mut player_pubkeys = Vec::new();
+            for request in &sorted_requests {
+                if let Some(pubkey) = request.get_public_key() {
+                    player_pubkeys.push(zk_mpc_node::UserPublicKey {
+                        user_id: request.get_user_id().to_string(),
+                        public_key: pubkey.to_string(),
+                    });
+                }
+            }
+            if player_pubkeys.is_empty() {
+                return Err("No player public keys found for RoleAssignment".to_string());
+            }
+            ProofOutputType::PrivateToPublic(player_pubkeys)
+        }
+        _ => ProofOutputType::Public,
+    };
+
+    let client = Client::new();
+    let req_to_node = ProofRequest {
+        proof_id: batch_request.batch_id.clone(),
+        circuit_type: identifier.clone(),
+        output_type,
+    };
+
+    let node_urls = CONFIG.zk_mpc_node_urls();
+    let mut responses = Vec::new();
+    for url in &node_urls {
+        let response = client
+            .post(url)
+            .json(&req_to_node)
+            .send()
+            .await
+            .map_err(|e| {
+                format!(
+                    "Failed to send request to {} for batch {}: {}",
+                    url, batch_request.batch_id, e
+                )
+            })?;
+        responses.push(response);
+    }
+
+    for (url, response) in node_urls.iter().zip(responses) {
+        response.json::<serde_json::Value>().await.map_err(|e| {
+            format!(
+                "Failed to parse JSON response from {} for batch {}: {}",
+                url, batch_request.batch_id, e
+            )
+        })?;
+    }
+
+    match check_status_with_retry(&batch_request.batch_id).await? {
+        (true, Some(output)) => Ok((identifier, output)),
+        (true, None) => Err(format!(
+            "Proof completed without output for batch {}",
+            batch_request.batch_id
+        )),
+        (false, _) => Err(format!("Proof failed for batch {}", batch_request.batch_id)),
+    }
+}
+
+pub async fn store_precomputed_batch_result(batch_id: String, result: BatchExecutionResult) {
+    let mut store = PRECOMPUTED_BATCH_RESULTS.lock().await;
+    store.insert(batch_id, result);
+}
+
+pub async fn take_precomputed_batch_result(batch_id: &str) -> Option<BatchExecutionResult> {
+    let mut store = PRECOMPUTED_BATCH_RESULTS.lock().await;
+    store.remove(batch_id)
+}
+
 pub async fn batch_proof_handling(
     state: AppState,
     room_id: &str,
     request: &ClientRequestType,
-) -> Result<String, String> {
-    let mut games = state.games.lock().await;
-    let game = match games.get_mut(room_id) {
-        Some(game) => game,
-        None => return Err("Game not found".to_string()),
+) -> Result<String, ProofHandlingError> {
+    let (batch_id, should_process) = {
+        let mut games = state.games.lock().await;
+        let game = match games.get_mut(room_id) {
+            Some(game) => game,
+            None => return Err(ProofHandlingError::Internal("Game not found".to_string())),
+        };
+
+        validate_phase_for_request(&game.phase, request)?;
+
+        let user_id = match &request {
+            ClientRequestType::Divination(info) => info.user_id.clone(),
+            ClientRequestType::RoleAssignment(info) => info.user_id.clone(),
+            ClientRequestType::AnonymousVoting(info) => info.user_id.clone(),
+            ClientRequestType::WinningJudge(info) => info.user_id.clone(),
+            ClientRequestType::KeyPublicize(info) => info.user_id.clone(),
+        };
+
+        // 計算結果の重複チェック
+        match request {
+            ClientRequestType::RoleAssignment(_) => {
+                if game.has_role_assignment() {
+                    return Err(ProofHandlingError::Conflict(
+                        "Role assignment has already been completed".to_string(),
+                    ));
+                }
+            }
+            ClientRequestType::Divination(_) => {
+                if game.has_divination_for_current_phase() {
+                    return Err(ProofHandlingError::Conflict(
+                        "Divination has already been completed for current phase".to_string(),
+                    ));
+                }
+            }
+            ClientRequestType::WinningJudge(_) => {
+                // GameResultが既に決定されている場合は重複
+                if game.result != GameResult::InProgress {
+                    return Err(ProofHandlingError::Conflict(
+                        "Winning judgement has already been completed for current phase"
+                            .to_string(),
+                    ));
+                }
+            }
+            ClientRequestType::AnonymousVoting(_) => {
+                // vote_resultsが既に存在し、現在のphaseで投票が完了している場合は重複
+                if !game.vote_results.is_empty() {
+                    return Err(ProofHandlingError::Conflict(
+                        "Voting has already been completed for current phase".to_string(),
+                    ));
+                }
+            }
+            ClientRequestType::KeyPublicize(_) => {
+                // キー公開は重複チェック対象外
+            }
+        }
+
+        game.chat_log
+            .add_system_message(format!("{} has sent a proof request.", user_id));
+
+        // バッチリクエストに追加
+        let enqueue_result =
+            game.add_request_to_batch(request.clone())
+                .map_err(|error| match error {
+                    BatchEnqueueError::Conflict(message) => ProofHandlingError::Conflict(message),
+                })?;
+        (enqueue_result.batch_id, enqueue_result.should_process)
     };
 
-    let user_id = match &request {
-        ClientRequestType::Divination(info) => info.user_id.clone(),
-        ClientRequestType::RoleAssignment(info) => info.user_id.clone(),
-        ClientRequestType::AnonymousVoting(info) => info.user_id.clone(),
-        ClientRequestType::WinningJudge(info) => info.user_id.clone(),
-        ClientRequestType::KeyPublicize(info) => info.user_id.clone(),
-    };
+    if should_process {
+        let state_for_worker = state.clone();
+        let room_id_for_worker = room_id.to_string();
+        tokio::spawn(async move {
+            let batch_snapshot = {
+                let mut games = state_for_worker.games.lock().await;
+                let Some(game) = games.get_mut(&room_id_for_worker) else {
+                    return;
+                };
+                if game.batch_request.requests.is_empty() {
+                    return;
+                }
+                game.batch_request.status = crate::models::game::BatchStatus::Processing;
+                game.batch_request.clone()
+            };
 
-    // 計算結果の重複チェック
-    match request {
-        ClientRequestType::RoleAssignment(_) => {
-            if game.has_role_assignment() {
-                return Err("Role assignment has already been completed".to_string());
+            let batch_id = batch_snapshot.batch_id.clone();
+            let execution_result = execute_batch_request(&batch_snapshot).await;
+            store_precomputed_batch_result(batch_id.clone(), execution_result).await;
+
+            let mut games = state_for_worker.games.lock().await;
+            if let Some(game) = games.get_mut(&room_id_for_worker) {
+                if game.batch_request.batch_id != batch_id {
+                    return;
+                }
+                game.process_current_batch(&state_for_worker).await;
             }
-        }
-        ClientRequestType::Divination(_) => {
-            if game.has_divination_for_current_phase() {
-                return Err("Divination has already been completed for current phase".to_string());
-            }
-        }
-        ClientRequestType::WinningJudge(_) => {
-            // GameResultが既に決定されている場合は重複
-            if game.result != crate::models::game::GameResult::InProgress {
-                return Err(
-                    "Winning judgement has already been completed for current phase".to_string(),
-                );
-            }
-        }
-        ClientRequestType::AnonymousVoting(_) => {
-            // vote_resultsが既に存在し、現在のphaseで投票が完了している場合は重複
-            if !game.vote_results.is_empty() {
-                return Err("Voting has already been completed for current phase".to_string());
-            }
-        }
-        ClientRequestType::KeyPublicize(_) => {
-            // キー公開は重複チェック対象外
-        }
+        });
     }
 
-    game.chat_log
-        .add_system_message(format!("{} has sent a proof request.", user_id));
-
-    // バッチリクエストに追加
-    let batch_id = game.add_request(request.clone(), &state).await;
-
     Ok(batch_id)
+}
+
+fn validate_phase_for_request(
+    phase: &GamePhase,
+    request: &ClientRequestType,
+) -> Result<(), ProofHandlingError> {
+    let is_valid = match request {
+        ClientRequestType::RoleAssignment(_)
+        | ClientRequestType::KeyPublicize(_) => matches!(phase, GamePhase::Night),
+        ClientRequestType::Divination(_) => {
+            matches!(phase, GamePhase::Night | GamePhase::DivinationProcessing)
+        }
+        ClientRequestType::AnonymousVoting(_) => matches!(phase, GamePhase::Voting),
+        ClientRequestType::WinningJudge(_) => {
+            matches!(
+                phase,
+                GamePhase::DivinationProcessing | GamePhase::Discussion | GamePhase::Result
+            )
+        }
+    };
+
+    if is_valid {
+        Ok(())
+    } else {
+        Err(ProofHandlingError::Unprocessable(format!(
+            "phase {:?} does not accept {:?} proof requests",
+            phase,
+            request.get_proof_type()
+        )))
+    }
 }
 
 // #[derive(Clone)]

--- a/packages/server/src/state.rs
+++ b/packages/server/src/state.rs
@@ -1,4 +1,7 @@
 use axum::extract::ws::Message;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{broadcast, Mutex};
 
@@ -6,15 +9,32 @@ use crate::blockchain::BlockchainClient;
 use crate::models::config::DebugConfig;
 use crate::models::{game::Game, room::Room};
 use crate::services::node_key::NodeKeyService;
-use crate::services::proof_job_service::ProofJobService;
+use crate::services::proof_job_service::{ProofJobService, ProofJobStatus};
 use crate::services::user_service::UserService;
 use crate::utils::config::CONFIG;
+
+const ROOM_EVENT_HISTORY_LIMIT: usize = 512;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoomEventEnvelope {
+    pub event_id: u64,
+    pub room_id: String,
+    pub timestamp: String,
+    pub payload: Value,
+}
+
+#[derive(Default)]
+struct RoomEventStore {
+    next_event_id: u64,
+    events: Vec<RoomEventEnvelope>,
+}
 
 #[derive(Clone)]
 pub struct AppState {
     pub rooms: Arc<Mutex<HashMap<String, Room>>>,
     pub games: Arc<Mutex<HashMap<String, Game>>>,
     pub channel: Arc<Mutex<HashMap<String, broadcast::Sender<Message>>>>,
+    room_event_store: Arc<Mutex<HashMap<String, RoomEventStore>>>,
     pub user_service: UserService,
     pub debug_config: Arc<DebugConfig>,
     pub node_key_service: Arc<NodeKeyService>,
@@ -28,6 +48,7 @@ impl AppState {
             rooms: Arc::new(Mutex::new(HashMap::new())),
             games: Arc::new(Mutex::new(HashMap::new())),
             channel: Arc::new(Mutex::new(HashMap::new())),
+            room_event_store: Arc::new(Mutex::new(HashMap::new())),
             user_service: UserService::new(),
             debug_config: Arc::new(DebugConfig::default()),
             node_key_service: Arc::new(NodeKeyService::new()),
@@ -47,30 +68,75 @@ impl AppState {
         }
     }
 
+    async fn create_room_event(&self, room_id: &str, payload: Value) -> RoomEventEnvelope {
+        let mut stores = self.room_event_store.lock().await;
+        let store = stores.entry(room_id.to_string()).or_default();
+        store.next_event_id += 1;
+
+        let event = RoomEventEnvelope {
+            event_id: store.next_event_id,
+            room_id: room_id.to_string(),
+            timestamp: Utc::now().to_rfc3339(),
+            payload,
+        };
+
+        store.events.push(event.clone());
+        if store.events.len() > ROOM_EVENT_HISTORY_LIMIT {
+            let drop_count = store.events.len() - ROOM_EVENT_HISTORY_LIMIT;
+            store.events.drain(0..drop_count);
+        }
+
+        event
+    }
+
+    pub async fn publish_room_event(&self, room_id: &str, payload: Value) -> Result<u64, String> {
+        let event = self.create_room_event(room_id, payload).await;
+        let message_text = serde_json::to_string(&event)
+            .map_err(|e| format!("Failed to serialize room event: {}", e))?;
+
+        let tx = self.get_or_create_room_channel(room_id).await;
+        tx.send(Message::Text(message_text.into()))
+            .map_err(|e| format!("Failed to broadcast room event: {}", e))?;
+
+        Ok(event.event_id)
+    }
+
+    pub async fn replay_room_events_since(
+        &self,
+        room_id: &str,
+        last_event_id: u64,
+    ) -> Vec<RoomEventEnvelope> {
+        let stores = self.room_event_store.lock().await;
+        let Some(store) = stores.get(room_id) else {
+            return Vec::new();
+        };
+
+        store
+            .events
+            .iter()
+            .filter(|event| event.event_id > last_event_id)
+            .cloned()
+            .collect()
+    }
+
     pub async fn broadcast_phase_change(
         &self,
         room_id: &str,
         from_phase: &str,
         to_phase: &str,
     ) -> Result<(), String> {
-        let tx = self.get_or_create_room_channel(room_id).await;
-
         let phase_notification = serde_json::json!({
             "message_type": "phase_change",
             "from_phase": from_phase,
             "to_phase": to_phase,
             "room_id": room_id,
-            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "timestamp": Utc::now().to_rfc3339(),
             "requires_dummy_request": from_phase == "Night" && to_phase == "DivinationProcessing"
         });
 
-        if let Ok(message_text) = serde_json::to_string(&phase_notification) {
-            if let Err(e) = tx.send(Message::Text(message_text)) {
-                return Err(format!("Failed to broadcast phase change: {}", e));
-            }
-        }
-
-        Ok(())
+        self.publish_room_event(room_id, phase_notification)
+            .await
+            .map(|_| ())
     }
 
     pub async fn broadcast_commitments_ready(
@@ -79,23 +145,17 @@ impl AppState {
         commitments_count: usize,
         total_players: usize,
     ) -> Result<(), String> {
-        let tx = self.get_or_create_room_channel(room_id).await;
-
         let commitments_ready_notification = serde_json::json!({
             "message_type": "commitments_ready",
             "room_id": room_id,
             "commitments_count": commitments_count,
             "total_players": total_players,
-            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "timestamp": Utc::now().to_rfc3339(),
         });
 
-        if let Ok(message_text) = serde_json::to_string(&commitments_ready_notification) {
-            if let Err(e) = tx.send(Message::Text(message_text)) {
-                return Err(format!("Failed to broadcast commitments ready: {}", e));
-            }
-        }
-
-        Ok(())
+        self.publish_room_event(room_id, commitments_ready_notification)
+            .await
+            .map(|_| ())
     }
 
     pub async fn broadcast_computation_result(
@@ -112,42 +172,57 @@ impl AppState {
             "result_data": result_data,
             "room_id": room_id,
             "target_player_id": target_player_id.clone(),
-            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "timestamp": Utc::now().to_rfc3339(),
             "batch_id": batch_id
         });
 
-        if let Ok(message_text) = serde_json::to_string(&computation_notification) {
-            // broadcast channelを使用して全員に送信
-            // クライアント側でtarget_player_idをチェックしてフィルタリング
-            let tx = self.get_or_create_room_channel(room_id).await;
-            if let Err(e) = tx.send(Message::Text(message_text)) {
-                return Err(format!("Failed to broadcast computation result: {}", e));
-            }
-        }
-
-        Ok(())
+        self.publish_room_event(room_id, computation_notification)
+            .await
+            .map(|_| ())
     }
 
     pub async fn broadcast_game_reset(&self, room_id: &str) -> Result<(), String> {
-        println!("🔄 Broadcasting game reset for room: {}", room_id);
-        let tx = self.get_or_create_room_channel(room_id).await;
-
         let reset_notification = serde_json::json!({
             "message_type": "game_reset",
             "room_id": room_id,
-            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "timestamp": Utc::now().to_rfc3339(),
         });
 
-        if let Ok(message_text) = serde_json::to_string(&reset_notification) {
-            println!("📤 Sending game reset notification: {}", message_text);
-            if let Err(e) = tx.send(Message::Text(message_text)) {
-                println!("❌ Failed to send game reset notification: {}", e);
-                return Err(format!("Failed to broadcast game reset: {}", e));
-            }
-            println!("✅ Game reset notification sent successfully");
-        }
+        self.publish_room_event(room_id, reset_notification)
+            .await
+            .map(|_| ())
+    }
 
-        Ok(())
+    pub async fn broadcast_room_state_changed(
+        &self,
+        room_id: &str,
+        reason: &str,
+    ) -> Result<(), String> {
+        let payload = serde_json::json!({
+            "message_type": "room_state_changed",
+            "room_id": room_id,
+            "reason": reason,
+            "timestamp": Utc::now().to_rfc3339(),
+        });
+        self.publish_room_event(room_id, payload).await.map(|_| ())
+    }
+
+    pub async fn broadcast_proof_job_status(
+        &self,
+        room_id: &str,
+        status: &ProofJobStatus,
+    ) -> Result<(), String> {
+        let payload = serde_json::json!({
+            "message_type": "proof_job_status",
+            "room_id": room_id,
+            "batch_id": status.batch_id,
+            "state": status.state,
+            "attempt_count": status.attempt_count,
+            "last_error": status.last_error,
+            "job_node_status": status.job_node_status,
+            "updated_at": status.updated_at.to_rfc3339(),
+        });
+        self.publish_room_event(room_id, payload).await.map(|_| ())
     }
 
     pub async fn save_chat_message(

--- a/packages/server/src/state.rs
+++ b/packages/server/src/state.rs
@@ -6,6 +6,7 @@ use crate::blockchain::BlockchainClient;
 use crate::models::config::DebugConfig;
 use crate::models::{game::Game, room::Room};
 use crate::services::node_key::NodeKeyService;
+use crate::services::proof_job_service::ProofJobService;
 use crate::services::user_service::UserService;
 use crate::utils::config::CONFIG;
 
@@ -17,6 +18,7 @@ pub struct AppState {
     pub user_service: UserService,
     pub debug_config: Arc<DebugConfig>,
     pub node_key_service: Arc<NodeKeyService>,
+    pub proof_job_service: Arc<ProofJobService>,
     pub blockchain_client: Arc<BlockchainClient>,
 }
 
@@ -29,6 +31,7 @@ impl AppState {
             user_service: UserService::new(),
             debug_config: Arc::new(DebugConfig::default()),
             node_key_service: Arc::new(NodeKeyService::new()),
+            proof_job_service: Arc::new(ProofJobService::new()),
             blockchain_client: Arc::new(BlockchainClient::new(&CONFIG)),
         }
     }

--- a/packages/server/src/utils/websocket.rs
+++ b/packages/server/src/utils/websocket.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::{
         ws::{Message, WebSocket},
-        Path, State, WebSocketUpgrade,
+        Path, Query, State, WebSocketUpgrade,
     },
     response::IntoResponse,
 };
@@ -45,6 +45,12 @@ struct ComputationResultNotification {
     batch_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct WebSocketConnectQuery {
+    #[serde(default)]
+    last_event_id: Option<u64>,
+}
+
 impl WebSocketMessage {
     fn to_chat_message(&self) -> ChatMessage {
         let message_type = match self.message_type.as_str() {
@@ -66,12 +72,20 @@ impl WebSocketMessage {
 pub async fn handler(
     State(state): State<AppState>,
     Path(room_id): Path<String>,
+    Query(query): Query<WebSocketConnectQuery>,
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, state.clone(), room_id))
+    ws.on_upgrade(move |socket| {
+        handle_socket(
+            socket,
+            state.clone(),
+            room_id,
+            query.last_event_id.unwrap_or(0),
+        )
+    })
 }
 
-pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String) {
+pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String, last_event_id: u64) {
     info!("New WebSocket connection established for room: {}", room_id);
     let tx = state.get_or_create_room_channel(&room_id).await;
 
@@ -82,6 +96,25 @@ pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String) {
     let room_id_for_send = room_id.clone();
     let room_id_for_receive = room_id.clone();
 
+    let replay_events = state
+        .replay_room_events_since(&room_id, last_event_id)
+        .await;
+    for event in replay_events {
+        match serde_json::to_string(&event) {
+            Ok(message_text) => {
+                if sender
+                    .send(Message::Text(message_text.into()))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(e) => eprintln!("Error serializing replay event: {}", e),
+        }
+    }
+
+    let state_for_receive = state.clone();
     let receive_task = tokio::spawn(async move {
         while let Some(Ok(msg)) = receiver.next().await {
             if let Message::Text(text) = msg {
@@ -96,19 +129,28 @@ pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String) {
 
                         // チャットメッセージに変換して保存
                         let chat_message = ws_message.to_chat_message();
-                        if let Err(e) = state
+                        if let Err(e) = state_for_receive
                             .save_chat_message(&room_id_for_receive, chat_message)
                             .await
                         {
                             eprintln!("Error saving chat message: {}", e);
                         }
 
-                        let response = serde_json::to_string(&ws_message).unwrap();
+                        let payload = match serde_json::to_value(&ws_message) {
+                            Ok(payload) => payload,
+                            Err(e) => {
+                                eprintln!("Error converting websocket message to json: {}", e);
+                                continue;
+                            }
+                        };
                         info!(
                             "Received valid message in room {}: {:?}",
-                            room_id_for_receive, response
+                            room_id_for_receive, ws_message
                         );
-                        if let Err(e) = tx.send(Message::Text(response)) {
+                        if let Err(e) = state_for_receive
+                            .publish_room_event(&room_id_for_receive, payload)
+                            .await
+                        {
                             eprintln!("Error sending message: {}", e);
                             break;
                         }
@@ -124,11 +166,19 @@ pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String) {
                             room_id: room_id_for_receive.clone(),
                         };
 
-                        if let Ok(error_response) = serde_json::to_string(&error_message) {
-                            info!("Sending error message: {}", error_response);
-                            if let Err(e) = tx.send(Message::Text(error_response)) {
-                                eprintln!("Error sending error message: {}", e);
+                        info!("Sending error message: {:?}", error_message);
+                        let error_payload = match serde_json::to_value(&error_message) {
+                            Ok(payload) => payload,
+                            Err(err) => {
+                                eprintln!("Error converting error message to json: {}", err);
+                                continue;
                             }
+                        };
+                        if let Err(err) = state_for_receive
+                            .publish_room_event(&room_id_for_receive, error_payload)
+                            .await
+                        {
+                            eprintln!("Error sending error message: {}", err);
                         }
                     }
                 }
@@ -139,15 +189,6 @@ pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String) {
     let room_id_for_send = room_id_for_send.clone();
     let send_task = tokio::spawn(async move {
         while let Ok(msg) = rx.recv().await {
-            if let Message::Text(text) = msg.clone() {
-                // メッセージがこのルームのものかを確認
-                if let Ok(ws_message) = serde_json::from_str::<WebSocketMessage>(&text) {
-                    if ws_message.room_id != room_id_for_send {
-                        continue; // 他のルームのメッセージはスキップ
-                    }
-                }
-            }
-
             info!("Sending message in room {}: {:?}", room_id_for_send, msg);
             if let Err(e) = sender.send(msg).await {
                 eprintln!("Error sending message: {}", e);

--- a/packages/server/tests/zk_proof_request_test.rs
+++ b/packages/server/tests/zk_proof_request_test.rs
@@ -197,6 +197,7 @@ fn setup_voting_dummy() -> ClientRequestType {
         user_id: "0".to_string(),
         prover_count: USER_NUM,
         encrypted_data: serde_json::to_string(&anon_voting_output).unwrap(),
+        is_dummy: false,
         public_key: None,
     };
     ClientRequestType::AnonymousVoting(prover_info)
@@ -285,6 +286,7 @@ async fn test_batch_request() -> Result<(), anyhow::Error> {
         user_id: "0".to_string(),
         prover_count: USER_NUM,
         encrypted_data: serde_json::to_string(&input_vec[0]).unwrap(),
+        is_dummy: false,
         public_key: None,
     };
     let request1 = ClientRequestType::AnonymousVoting(prover_info_1);
@@ -295,6 +297,7 @@ async fn test_batch_request() -> Result<(), anyhow::Error> {
         user_id: "1".to_string(),
         prover_count: USER_NUM,
         encrypted_data: serde_json::to_string(&input_vec[1]).unwrap(),
+        is_dummy: false,
         public_key: None,
     };
     let request2 = ClientRequestType::AnonymousVoting(prover_info_2);
@@ -305,6 +308,7 @@ async fn test_batch_request() -> Result<(), anyhow::Error> {
         user_id: "2".to_string(),
         prover_count: USER_NUM,
         encrypted_data: serde_json::to_string(&input_vec[2]).unwrap(),
+        is_dummy: false,
         public_key: None,
     };
     let request3 = ClientRequestType::AnonymousVoting(prover_info_3);

--- a/packages/server/tests/zk_proof_request_test.rs
+++ b/packages/server/tests/zk_proof_request_test.rs
@@ -290,7 +290,10 @@ async fn test_batch_request() -> Result<(), anyhow::Error> {
         public_key: None,
     };
     let request1 = ClientRequestType::AnonymousVoting(prover_info_1);
-    let batch_id1 = game.add_request(request1, &state).await;
+    let enqueue1 = game
+        .add_request(request1)
+        .expect("Failed to enqueue first request");
+    let batch_id1 = enqueue1.batch_id.clone();
 
     // 2つ目のリクエストを追加
     let prover_info_2 = ProverInfo {
@@ -301,7 +304,10 @@ async fn test_batch_request() -> Result<(), anyhow::Error> {
         public_key: None,
     };
     let request2 = ClientRequestType::AnonymousVoting(prover_info_2);
-    let batch_id2 = game.add_request(request2, &state).await;
+    let enqueue2 = game
+        .add_request(request2)
+        .expect("Failed to enqueue second request");
+    let batch_id2 = enqueue2.batch_id.clone();
 
     // 3つ目のリクエストを追加（これでバッチサイズに達する）
     let prover_info_3 = ProverInfo {
@@ -312,7 +318,13 @@ async fn test_batch_request() -> Result<(), anyhow::Error> {
         public_key: None,
     };
     let request3 = ClientRequestType::AnonymousVoting(prover_info_3);
-    let batch_id3 = game.add_request(request3, &state).await;
+    let enqueue3 = game
+        .add_request(request3)
+        .expect("Failed to enqueue third request");
+    let batch_id3 = enqueue3.batch_id.clone();
+    if enqueue3.should_process {
+        game.apply_proof_result(&state).await;
+    }
 
     // 同じバッチIDであることを確認
     assert_eq!(batch_id1, batch_id2);
@@ -323,7 +335,10 @@ async fn test_batch_request() -> Result<(), anyhow::Error> {
 
     // 新しいリクエストは新しいバッチIDを取得することを確認
     let request4 = setup_voting_dummy();
-    let batch_id4 = game.add_request(request4, &state).await;
+    let enqueue4 = game
+        .add_request(request4)
+        .expect("Failed to enqueue fourth request");
+    let batch_id4 = enqueue4.batch_id;
     assert_ne!(batch_id1, batch_id4);
 
     sleep(Duration::from_secs(30)).await; // バッチ処理が完了するのを待つ


### PR DESCRIPTION
## 概要(日本語)
本PRは、proofバッチ処理の安定化と通信経路の改善を段階的に実施したものです。

- フェーズごとのproof受付条件を明確化し、不正なフェーズでのリクエストを適切に拒否
- バッチ処理のロック範囲を縮小して、同時アクセス時の詰まりを軽減
- ProofJobキュー（Phase2）を導入して重いproof実行をAPI処理から分離
- Phase3-liteとして、WebSocketイベントに`event_id`を付与し、`last_event_id`ベースの差分再送とギャップ検知を追加
- 5秒ポーリング依存をやめ、WSイベント駆動で状態同期する構成へ移行

## Summary (English)
This PR improves proof-processing stability and realtime synchronization in incremental phases.

- Enforces phase-aware proof acceptance and rejects invalid requests with clearer behavior
- Reduces lock scope in batch handling to lower contention under concurrent access
- Introduces a Phase2 proof-job queue so heavy proof execution is decoupled from API request latency
- Implements Phase3-lite realtime flow: WebSocket `event_id`, replay from `last_event_id`, and gap detection
- Removes 5-second polling dependency and shifts to event-driven synchronization

## Changes
- Server
  - Added proof job queue service and integrated it into batch proof handling
    - `packages/server/src/services/proof_job_service.rs`
    - `packages/server/src/services/zk_proof.rs`
    - `packages/server/src/state.rs`
    - `packages/server/src/models/game.rs`
  - Added proof job status API endpoint
    - `POST/GET routing updates in packages/server/src/routes/game.rs`
  - Added room event envelope with in-memory event store (`event_id`, replay buffer)
    - `packages/server/src/state.rs`
  - Updated WebSocket handler to support `last_event_id` reconnect replay
    - `packages/server/src/utils/websocket.rs`
  - Added room state change broadcasts on join/leave/ready/start/end/phase-advance
    - `packages/server/src/routes/room.rs`
    - `packages/server/src/routes/game.rs`

- Frontend
  - Added WebSocket event envelope handling (`event_id` tracking, gap detection, reconnect replay query)
    - `packages/nextjs/hooks/useGameWebSocket.ts`
  - Removed 5-second polling and switched to WS-triggered refetch
    - `packages/nextjs/hooks/useGameInfo.ts`
  - Updated E2E websocket message parser for enveloped payloads
    - `packages/nextjs/__tests__/e2e/circuits/setup.ts`

- Additional stabilization already included in this branch history
  - Synchronized divination request timing at phase transition
  - Fixed divination circuit behavior for dead-player scenarios
  - Refactored batch handling to reduce lock scope

## Related
- N/A (関連チケット未紐付け)