### PR TITLE
RoleAssignment share delivery hardening and websocket stabilization

### DIFF
--- a/packages/mpc-circuits/src/factory.rs
+++ b/packages/mpc-circuits/src/factory.rs
@@ -469,16 +469,17 @@ impl CircuitFactory {
                 buffer
             }
             BuiltinCircuit::RoleAssignment(circuit) => {
-                let roles = circuit.calculate_output().sync_reveal();
+                let role_shares = circuit.calculate_output();
 
-                // Vec<Fr>を文字列の配列に変換してJSON化
-                let role_strings: Vec<String> = roles
+                // 各ノードのローカル share（Fr）を文字列化して返す。
+                // 復元はクライアント側で全ノード share を合成して行う。
+                let role_share_strings: Vec<String> = role_shares
                     .iter()
-                    .map(|role_field| role_field.into_repr().to_string())
+                    .map(|role_share| role_share.unwrap_as_public().into_repr().to_string())
                     .collect();
 
                 // JSONとしてシリアライズ
-                serde_json::to_vec(&role_strings).unwrap()
+                serde_json::to_vec(&role_share_strings).unwrap()
             }
         }
     }

--- a/packages/mpc-circuits/src/factory.rs
+++ b/packages/mpc-circuits/src/factory.rs
@@ -4,6 +4,7 @@ use ark_serialize::CanonicalSerialize;
 use ark_std::{test_rng, UniformRand};
 use mpc_algebra::reveal::Reveal;
 use mpc_algebra::FromLocal;
+use serde::Serialize;
 use zk_mpc::circuits::ElGamalLocalOrMPC;
 use zk_mpc::{circuits::LocalOrMPC, marlin::MFr};
 
@@ -15,6 +16,15 @@ use mpc_algebra_wasm::{
 use crate::*;
 
 pub struct CircuitFactory;
+
+#[derive(Serialize)]
+struct RoleAssignmentOutputShare {
+    schema_version: &'static str,
+    role_share: String,
+    role_share_encoding: &'static str,
+    werewolf_mates_mask_share: String,
+    werewolf_mates_mask_share_encoding: &'static str,
+}
 
 impl CircuitFactory {
     pub fn create_local_circuit(
@@ -469,17 +479,25 @@ impl CircuitFactory {
                 buffer
             }
             BuiltinCircuit::RoleAssignment(circuit) => {
-                let role_shares = circuit.calculate_output();
+                let role_outputs = circuit.calculate_output_with_werewolf_mates_mask();
 
-                // 各ノードのローカル share（Fr）を文字列化して返す。
-                // 復元はクライアント側で全ノード share を合成して行う。
-                let role_share_strings: Vec<String> = role_shares
+                let serialized_outputs: Vec<RoleAssignmentOutputShare> = role_outputs
                     .iter()
-                    .map(|role_share| role_share.unwrap_as_public().into_repr().to_string())
+                    .map(|output| RoleAssignmentOutputShare {
+                        schema_version: "role_assignment_share_v2",
+                        role_share: output.role_share.unwrap_as_public().into_repr().to_string(),
+                        role_share_encoding: "bn254_fr_decimal_string",
+                        werewolf_mates_mask_share: output
+                            .werewolf_mates_mask_share
+                            .unwrap_as_public()
+                            .into_repr()
+                            .to_string(),
+                        werewolf_mates_mask_share_encoding: "player_index_bitmask_lsb0",
+                    })
                     .collect();
 
                 // JSONとしてシリアライズ
-                serde_json::to_vec(&role_share_strings).unwrap()
+                serde_json::to_vec(&serialized_outputs).unwrap()
             }
         }
     }

--- a/packages/mpc-circuits/src/traits/circuits.rs
+++ b/packages/mpc-circuits/src/traits/circuits.rs
@@ -25,7 +25,7 @@ use mpc_algebra::MpcFpVar;
 use mpc_algebra::Reveal;
 use mpc_algebra::{BitDecomposition, BooleanWire};
 use mpc_algebra::{EqualityZero, ModulusConversion};
-use mpc_algebra_wasm::{calc_shuffle_matrix, Role};
+use mpc_algebra_wasm::Role;
 use nalgebra as na;
 use std::collections::HashSet;
 use zk_mpc::circuits::{ElGamalLocalOrMPC, LocalOrMPC};
@@ -1181,37 +1181,88 @@ impl RoleAssignmentCircuit<MpcField<Fr>> {
     // Vec<MpcField<Fr>> は各プレイヤーの役職IDを表す。0が村人、1が占い師、2が人狼など。
     pub fn calculate_output(&self) -> Vec<MpcField<Fr>> {
         let num_players = self.private_input.len();
+        if num_players == 0 {
+            return Vec::new();
+        }
 
         let grouping_parameter = &self.public_input.grouping_parameter;
+        let tau_matrix = self.public_input.tau_matrix.clone();
+        let matrix_size = tau_matrix.nrows();
 
-        let shuffle_matrix = self
+        let shuffle_matrices = self
             .private_input
             .iter()
             .map(|input| input.shuffle_matrices.clone())
             .collect::<Vec<_>>();
-
-        let revealed_shuffle_matrix = shuffle_matrix
+        let inverse_shuffle_matrices = self
+            .private_input
             .iter()
-            .map(|row| row.map(|x| x.sync_reveal()))
+            .rev()
+            .map(|input| input.shuffle_matrices.transpose())
             .collect::<Vec<_>>();
 
-        let mut output_vec = Vec::new();
+        let matrix_m = shuffle_matrices
+            .iter()
+            .skip(1)
+            .fold(shuffle_matrices[0].clone(), |acc, x| acc * x);
+        let inverse_matrix_m = inverse_shuffle_matrices
+            .iter()
+            .skip(1)
+            .fold(inverse_shuffle_matrices[0].clone(), |acc, x| acc * x);
 
-        for id in 0..num_players {
-            let (role, _role_val, _player_ids) =
-                calc_shuffle_matrix(grouping_parameter, &revealed_shuffle_matrix, id).unwrap();
+        // rho = M^-1 * tau * M
+        let rho = inverse_matrix_m * &tau_matrix * &matrix_m;
 
-            match role {
-                Role::Villager => {
-                    output_vec.push(MpcField::<Fr>::from(0u32));
-                }
-                Role::FortuneTeller => {
-                    output_vec.push(MpcField::<Fr>::from(1u32));
-                }
-                Role::Werewolf => {
-                    output_vec.push(MpcField::<Fr>::from(2u32));
-                }
+        let mut rho_sequence = Vec::with_capacity(num_players);
+        let mut current_rho = rho.clone();
+        for _ in 0..num_players {
+            rho_sequence.push(current_rho.clone());
+            current_rho *= rho.clone();
+        }
+
+        let role_id_lookup = (0..matrix_size)
+            .map(|idx| match grouping_parameter.get_corresponding_role(idx) {
+                Role::Villager => MpcField::<Fr>::from(0u32),
+                Role::FortuneTeller => MpcField::<Fr>::from(1u32),
+                Role::Werewolf => MpcField::<Fr>::from(2u32),
+            })
+            .collect::<Vec<_>>();
+
+        let stair_vector = na::DVector::from(
+            (0..matrix_size)
+                .map(|idx| MpcField::<Fr>::from(idx as u32))
+                .collect::<Vec<_>>(),
+        );
+
+        let mut output_vec = Vec::with_capacity(num_players);
+        for player_id in 0..num_players {
+            let mut unit_vec = na::DVector::<MpcField<Fr>>::zeros(matrix_size);
+            unit_vec[player_id] = MpcField::<Fr>::one();
+
+            // rho^1(i), rho^2(i), ..., rho^n(i) を share のまま index 値へ変換
+            let mut role_path = Vec::with_capacity(num_players);
+            for rho_i in &rho_sequence {
+                let moved = rho_i * unit_vec.clone();
+                role_path.push(moved.dot(&stair_vector));
             }
+
+            // role_val = max(role_path) を share のまま求める
+            let mut role_value = role_path[0];
+            for candidate in role_path.iter().skip(1) {
+                let le_like = role_value.sync_is_smaller_than(candidate).field();
+                let is_equal = (role_value - *candidate).sync_is_zero_shared().field();
+                let is_new_max = le_like * (MpcField::<Fr>::one() - is_equal);
+                role_value += (*candidate - role_value) * is_new_max;
+            }
+
+            // role_val (公開インデックス) -> 役職ID(0/1/2) を share のまま変換
+            let mut role_id = MpcField::<Fr>::zero();
+            for (idx, mapped_role_id) in role_id_lookup.iter().enumerate() {
+                let is_eq =
+                    (role_value - MpcField::<Fr>::from(idx as u32)).sync_is_zero_shared().field();
+                role_id += *mapped_role_id * is_eq;
+            }
+            output_vec.push(role_id);
         }
 
         output_vec

--- a/packages/mpc-circuits/src/traits/circuits.rs
+++ b/packages/mpc-circuits/src/traits/circuits.rs
@@ -31,6 +31,12 @@ use std::collections::HashSet;
 use zk_mpc::circuits::{ElGamalLocalOrMPC, LocalOrMPC};
 use zk_mpc::field::*;
 
+#[derive(Clone, Copy)]
+pub struct RoleAssignmentPlayerShares<F> {
+    pub role_share: F,
+    pub werewolf_mates_mask_share: F,
+}
+
 impl AnonymousVotingCircuit<Fr> {
     pub fn calculate_output(&self) -> Fr {
         if self.private_input.is_empty() {
@@ -1266,6 +1272,48 @@ impl RoleAssignmentCircuit<MpcField<Fr>> {
         }
 
         output_vec
+    }
+
+    pub fn calculate_output_with_werewolf_mates_mask(
+        &self,
+    ) -> Vec<RoleAssignmentPlayerShares<MpcField<Fr>>> {
+        let role_shares = self.calculate_output();
+        let num_players = role_shares.len();
+        if num_players == 0 {
+            return Vec::new();
+        }
+
+        let werewolf_flags = role_shares
+            .iter()
+            .map(|role_share| {
+                (*role_share - MpcField::<Fr>::from(2u32))
+                    .sync_is_zero_shared()
+                    .field()
+            })
+            .collect::<Vec<_>>();
+
+        let mut outputs = Vec::with_capacity(num_players);
+        for i in 0..num_players {
+            let mut teammate_mask_share = MpcField::<Fr>::zero();
+            let self_is_werewolf = werewolf_flags[i];
+
+            for j in 0..num_players {
+                if i == j {
+                    continue;
+                }
+
+                let bit = 1u32.checked_shl(j as u32).unwrap_or(0);
+                let weight = MpcField::<Fr>::from(bit);
+                teammate_mask_share += weight * self_is_werewolf * werewolf_flags[j];
+            }
+
+            outputs.push(RoleAssignmentPlayerShares {
+                role_share: role_shares[i],
+                werewolf_mates_mask_share: teammate_mask_share,
+            });
+        }
+
+        outputs
     }
 }
 

--- a/packages/nextjs/__tests__/e2e/circuits/helpers/api.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/helpers/api.ts
@@ -400,6 +400,7 @@ export class CircuitTestClient {
     roleAssignmentInput: RoleAssignmentInput,
     playerCount: number,
     authToken?: string,
+    requesterPlayerId?: string,
   ): Promise<any> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -416,7 +417,7 @@ export class CircuitTestClient {
     const requestBody = {
       proof_type: "RoleAssignment",
       data: {
-        user_id: String(roleAssignmentInput.privateInput.id),
+        user_id: requesterPlayerId ? String(requesterPlayerId) : String(roleAssignmentInput.privateInput.id),
         prover_count: playerCount,
         encrypted_data: encryptedRoleAssignment,
         public_key: roleAssignmentInput.publicKey,

--- a/packages/nextjs/__tests__/e2e/circuits/helpers/game-setup.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/helpers/game-setup.ts
@@ -207,6 +207,7 @@ export class GameSetupHelper {
           roleAssignmentInput,
           players.length,
           player.token,
+          player.id,
         );
         const batchId = this.extractBatchId(response);
         if (batchId) {

--- a/packages/nextjs/__tests__/e2e/circuits/integration.full.test.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/integration.full.test.ts
@@ -1,6 +1,7 @@
 import { CryptoHelper } from "./helpers/crypto";
 import { GameSetupHelper, checkWebSocketConnections, createTestSetup } from "./setup";
 import { GameInfo } from "~~/types/game";
+import { getPrivateGameInfo } from "~~/utils/privateGameInfoUtils";
 
 type DivinationStrategy = "next-player" | "last-player";
 type VotingStrategy = "ring" | "focus-player-2" | "split-vote";
@@ -92,6 +93,33 @@ async function runFullScenarioFlow(scenario: FullScenario): Promise<void> {
   deliveries.forEach(delivery => {
     expect(delivery.receiverPlayerId).toBe(delivery.targetPlayerId);
   });
+
+  if (scenario.werewolfCount >= 2) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    const privateInfos = players
+      .map(player => getPrivateGameInfo(roomId, player.id))
+      .filter((info): info is NonNullable<typeof info> => Boolean(info));
+    const werewolves = privateInfos.filter(info => info.playerRole === "Werewolf");
+    const werewolfIdSet = new Set(werewolves.map(info => info.playerId));
+
+    expect(werewolves.length).toBe(scenario.werewolfCount);
+
+    werewolves.forEach(werewolfInfo => {
+      const teammateIds = werewolfInfo.werewolfTeammateIds ?? [];
+      expect(teammateIds.length).toBe(scenario.werewolfCount - 1);
+      expect(teammateIds).not.toContain(werewolfInfo.playerId);
+      teammateIds.forEach(teammateId => {
+        expect(werewolfIdSet.has(teammateId)).toBe(true);
+      });
+    });
+
+    privateInfos
+      .filter(info => info.playerRole !== "Werewolf")
+      .forEach(info => {
+        expect(info.werewolfTeammateIds ?? []).toHaveLength(0);
+      });
+  }
 
   gameState = await global.apiClient.getGameState(roomId);
   await GameSetupHelper.submitKeyPublicizeRequests(roomId, players, gameState);

--- a/packages/nextjs/__tests__/e2e/circuits/integration.full.test.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/integration.full.test.ts
@@ -87,6 +87,11 @@ async function runFullScenarioFlow(scenario: FullScenario): Promise<void> {
   await GameSetupHelper.submitPlayerCommitments(roomId, players, gameState);
   await new Promise(resolve => setTimeout(resolve, 3000));
   await GameSetupHelper.submitRoleAssignmentRequests(roomId, players, gameState);
+  const deliveries = global.roleAssignmentDeliveries ?? [];
+  expect(deliveries.length).toBeGreaterThan(0);
+  deliveries.forEach(delivery => {
+    expect(delivery.receiverPlayerId).toBe(delivery.targetPlayerId);
+  });
 
   gameState = await global.apiClient.getGameState(roomId);
   await GameSetupHelper.submitKeyPublicizeRequests(roomId, players, gameState);

--- a/packages/nextjs/__tests__/e2e/circuits/integration.test.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/integration.test.ts
@@ -96,6 +96,12 @@ describe("ZK Werewolf Integration E2E Tests", () => {
     console.log(`✅ Updated game state (Phase: ${updatedGameState.phase})`);
     console.log(`   Players: ${updatedGameState.players?.length || 0}`);
 
+    const deliveries = global.roleAssignmentDeliveries ?? [];
+    expect(deliveries.length).toBeGreaterThan(0);
+    deliveries.forEach(delivery => {
+      expect(delivery.receiverPlayerId).toBe(delivery.targetPlayerId);
+    });
+
     console.log("\n✅ Test 2 completed: Commitments and role assignment successful\n");
   }, 300000);
 

--- a/packages/nextjs/__tests__/e2e/circuits/setup.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/setup.ts
@@ -105,10 +105,33 @@ const roleShareBuffers = new Map<
   string,
   {
     requiredShares: number;
-    sharesByNode: Map<number, bigint>;
+    roleSharesByNode: Map<number, bigint>;
+    werewolfMaskSharesByNode: Map<number, bigint>;
     completed: boolean;
   }
 >();
+
+function decodeWerewolfTeammateIdsForTest(
+  maskValue: bigint,
+  myRole: "Villager" | "Seer" | "Werewolf",
+  myPlayerId: string,
+): string[] {
+  if (myRole !== "Werewolf") {
+    return [];
+  }
+
+  const players = global.testPlayers ?? [];
+  const normalizedMask = normalizeFieldElement(maskValue);
+  const teammateIds: string[] = [];
+  for (let index = 0; index < players.length; index += 1) {
+    const bit = (normalizedMask >> BigInt(index)) & 1n;
+    if (bit !== 1n) continue;
+    const teammateId = players[index]?.id;
+    if (!teammateId || teammateId === myPlayerId) continue;
+    teammateIds.push(teammateId);
+  }
+  return teammateIds;
+}
 
 function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payload: any): void {
   const targetPlayerId = payload?.target_player_id as string | undefined;
@@ -125,7 +148,10 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
   const nonce = encryptedRoleShare.nonce as string | undefined;
   const nodeIdRaw = encryptedRoleShare.node_id as number | string | undefined;
   const requiredSharesRaw = encryptedRoleShare.required_shares as number | string | undefined;
-  const shareEncoding = encryptedRoleShare.share_encoding as string | undefined;
+  const shareEncoding =
+    (encryptedRoleShare.role_share_encoding as string | undefined) ||
+    (encryptedRoleShare.share_encoding as string | undefined);
+  const werewolfMaskShareEncoding = encryptedRoleShare.werewolf_mates_mask_share_encoding as string | undefined;
   const nodeId = typeof nodeIdRaw === "string" ? Number(nodeIdRaw) : nodeIdRaw;
   const requiredShares = typeof requiredSharesRaw === "string" ? Number(requiredSharesRaw) : requiredSharesRaw;
   const batchId = payload?.batch_id as string | undefined;
@@ -139,6 +165,9 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
   if (shareEncoding && shareEncoding !== "bn254_fr_decimal_string") {
     return;
   }
+  if (werewolfMaskShareEncoding && werewolfMaskShareEncoding !== "player_index_bitmask_lsb0") {
+    return;
+  }
   if (!batchId) {
     return;
   }
@@ -146,10 +175,11 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
   const bufferKey = `${roomId}:${playerId}:${batchId}`;
   const existingBuffer = roleShareBuffers.get(bufferKey) ?? {
     requiredShares: requiredShares as number,
-    sharesByNode: new Map<number, bigint>(),
+    roleSharesByNode: new Map<number, bigint>(),
+    werewolfMaskSharesByNode: new Map<number, bigint>(),
     completed: false,
   };
-  if (existingBuffer.completed || existingBuffer.sharesByNode.has(nodeId)) {
+  if (existingBuffer.completed || existingBuffer.roleSharesByNode.has(nodeId)) {
     return;
   }
 
@@ -168,34 +198,51 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
   try {
     const decryptedBinary = cryptoManager.decryptBinary(encrypted, nonce, senderPublicKey);
     const decryptedString = new TextDecoder("utf-8").decode(decryptedBinary);
-    const parsedShare = JSON.parse(decryptedString) as { role_share?: string };
+    const parsedShare = JSON.parse(decryptedString) as {
+      role_share?: string;
+      werewolf_mates_mask_share?: string;
+    };
     if (!parsedShare || typeof parsedShare.role_share !== "string") {
       throw new Error("Invalid role payload");
     }
+    const werewolfMaskShareString =
+      typeof parsedShare.werewolf_mates_mask_share === "string" ? parsedShare.werewolf_mates_mask_share : "0";
     const shareValue = normalizeFieldElement(BigInt(parsedShare.role_share));
+    const werewolfMaskShareValue = normalizeFieldElement(BigInt(werewolfMaskShareString));
     existingBuffer.requiredShares = Math.max(existingBuffer.requiredShares, requiredShares as number);
-    existingBuffer.sharesByNode.set(nodeId, shareValue);
+    existingBuffer.roleSharesByNode.set(nodeId, shareValue);
+    existingBuffer.werewolfMaskSharesByNode.set(nodeId, werewolfMaskShareValue);
     roleShareBuffers.set(bufferKey, existingBuffer);
 
-    if (existingBuffer.sharesByNode.size < existingBuffer.requiredShares) {
+    if (existingBuffer.roleSharesByNode.size < existingBuffer.requiredShares) {
       return;
     }
 
     let combinedShare = 0n;
-    for (const share of existingBuffer.sharesByNode.values()) {
+    for (const share of existingBuffer.roleSharesByNode.values()) {
       combinedShare = normalizeFieldElement(combinedShare + share);
     }
+
+    let combinedWerewolfMask = 0n;
+    for (const share of existingBuffer.werewolfMaskSharesByNode.values()) {
+      combinedWerewolfMask = normalizeFieldElement(combinedWerewolfMask + share);
+    }
     const roleName = decodeRoleName(combinedShare);
+    const werewolfTeammateIds = decodeWerewolfTeammateIdsForTest(combinedWerewolfMask, roleName, playerId);
     const existingInfo = getPrivateGameInfo(roomId, playerId);
 
     if (!existingInfo) {
       setPrivateGameInfo(roomId, {
         playerId,
         playerRole: roleName as any,
+        werewolfTeammateIds,
         hasActed: false,
       });
-    } else if (existingInfo.playerRole !== roleName) {
-      updatePrivateGameInfo(roomId, playerId, { playerRole: roleName as any });
+    } else if (
+      existingInfo.playerRole !== roleName ||
+      JSON.stringify(existingInfo.werewolfTeammateIds ?? []) !== JSON.stringify(werewolfTeammateIds)
+    ) {
+      updatePrivateGameInfo(roomId, playerId, { playerRole: roleName as any, werewolfTeammateIds });
     }
 
     existingBuffer.completed = true;

--- a/packages/nextjs/__tests__/e2e/circuits/setup.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/setup.ts
@@ -71,6 +71,10 @@ declare global {
   var testPlayers: TestPlayer[];
   // eslint-disable-next-line no-var
   var testSockets: any[] | undefined;
+  // eslint-disable-next-line no-var
+  var roleAssignmentDeliveries:
+    | Array<{ receiverPlayerId: string; targetPlayerId?: string; batchId?: string }>
+    | undefined;
 }
 
 export { GameSetupHelper };
@@ -83,12 +87,28 @@ function getMpcNodePublicKeys(): string[] {
   ];
 }
 
-function decodeRoleName(roleHex: string): "Villager" | "Seer" | "Werewolf" {
-  const roleId = (BigInt("0x" + roleHex) % BigInt(3)).toString();
-  if (roleId === "1") return "Seer";
-  if (roleId === "2") return "Werewolf";
+const BN254_SCALAR_MODULUS = BigInt("21888242871839275222246405745257275088548364400416034343698204186575808495617");
+
+const normalizeFieldElement = (value: bigint): bigint => {
+  const reduced = value % BN254_SCALAR_MODULUS;
+  return reduced >= 0n ? reduced : reduced + BN254_SCALAR_MODULUS;
+};
+
+function decodeRoleName(roleValue: bigint): "Villager" | "Seer" | "Werewolf" {
+  const roleId = normalizeFieldElement(roleValue) % 3n;
+  if (roleId === 1n) return "Seer";
+  if (roleId === 2n) return "Werewolf";
   return "Villager";
 }
+
+const roleShareBuffers = new Map<
+  string,
+  {
+    requiredShares: number;
+    sharesByNode: Map<number, bigint>;
+    completed: boolean;
+  }
+>();
 
 function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payload: any): void {
   const targetPlayerId = payload?.target_player_id as string | undefined;
@@ -96,17 +116,40 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
     return;
   }
 
-  const encryptedRole = payload?.result_data?.encrypted_role;
-  if (!encryptedRole) {
+  const encryptedRoleShare = payload?.result_data?.encrypted_role_share;
+  if (!encryptedRoleShare) {
     return;
   }
 
-  const encrypted = encryptedRole.encrypted as string | undefined;
-  const nonce = encryptedRole.nonce as string | undefined;
-  const nodeIdRaw = encryptedRole.node_id as number | string | undefined;
+  const encrypted = encryptedRoleShare.encrypted as string | undefined;
+  const nonce = encryptedRoleShare.nonce as string | undefined;
+  const nodeIdRaw = encryptedRoleShare.node_id as number | string | undefined;
+  const requiredSharesRaw = encryptedRoleShare.required_shares as number | string | undefined;
+  const shareEncoding = encryptedRoleShare.share_encoding as string | undefined;
   const nodeId = typeof nodeIdRaw === "string" ? Number(nodeIdRaw) : nodeIdRaw;
+  const requiredShares = typeof requiredSharesRaw === "string" ? Number(requiredSharesRaw) : requiredSharesRaw;
+  const batchId = payload?.batch_id as string | undefined;
 
   if (!encrypted || !nonce || typeof nodeId !== "number") {
+    return;
+  }
+  if (!Number.isFinite(requiredShares) || (requiredShares ?? 0) <= 0) {
+    return;
+  }
+  if (shareEncoding && shareEncoding !== "bn254_fr_decimal_string") {
+    return;
+  }
+  if (!batchId) {
+    return;
+  }
+
+  const bufferKey = `${roomId}:${playerId}:${batchId}`;
+  const existingBuffer = roleShareBuffers.get(bufferKey) ?? {
+    requiredShares: requiredShares as number,
+    sharesByNode: new Map<number, bigint>(),
+    completed: false,
+  };
+  if (existingBuffer.completed || existingBuffer.sharesByNode.has(nodeId)) {
     return;
   }
 
@@ -125,12 +168,24 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
   try {
     const decryptedBinary = cryptoManager.decryptBinary(encrypted, nonce, senderPublicKey);
     const decryptedString = new TextDecoder("utf-8").decode(decryptedBinary);
-    const roleData = JSON.parse(decryptedString) as string[];
-    if (!Array.isArray(roleData) || roleData.length === 0 || typeof roleData[0] !== "string") {
+    const parsedShare = JSON.parse(decryptedString) as { role_share?: string };
+    if (!parsedShare || typeof parsedShare.role_share !== "string") {
       throw new Error("Invalid role payload");
     }
+    const shareValue = normalizeFieldElement(BigInt(parsedShare.role_share));
+    existingBuffer.requiredShares = Math.max(existingBuffer.requiredShares, requiredShares as number);
+    existingBuffer.sharesByNode.set(nodeId, shareValue);
+    roleShareBuffers.set(bufferKey, existingBuffer);
 
-    const roleName = decodeRoleName(roleData[0]);
+    if (existingBuffer.sharesByNode.size < existingBuffer.requiredShares) {
+      return;
+    }
+
+    let combinedShare = 0n;
+    for (const share of existingBuffer.sharesByNode.values()) {
+      combinedShare = normalizeFieldElement(combinedShare + share);
+    }
+    const roleName = decodeRoleName(combinedShare);
     const existingInfo = getPrivateGameInfo(roomId, playerId);
 
     if (!existingInfo) {
@@ -142,6 +197,9 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
     } else if (existingInfo.playerRole !== roleName) {
       updatePrivateGameInfo(roomId, playerId, { playerRole: roleName as any });
     }
+
+    existingBuffer.completed = true;
+    roleShareBuffers.set(bufferKey, existingBuffer);
 
     console.log(`   🔐 [${playerId}] Role reflected from encrypted assignment: ${roleName}`);
   } catch (error) {
@@ -174,9 +232,9 @@ async function openTestWebSockets(roomId: string, players: TestPlayer[]): Promis
 
   const sockets: any[] = [];
   const wsConstructor = WS.WebSocket ? WS.WebSocket : WS;
-  const wsUrl = `${process.env.NEXT_PUBLIC_WS_URL || "ws://127.0.0.1:8080/api"}/room/${roomId}/ws`;
+  const wsBaseUrl = `${process.env.NEXT_PUBLIC_WS_URL || "ws://127.0.0.1:8080/api"}/room/${roomId}/ws`;
 
-  console.log(`   Connecting to: ${wsUrl}`);
+  console.log(`   Connecting to: ${wsBaseUrl}`);
 
   // 各プレイヤーのWebSocket接続を並列で開く
   const connectionPromises = players.map(
@@ -187,6 +245,7 @@ async function openTestWebSockets(roomId: string, players: TestPlayer[]): Promis
         }, 5000);
 
         try {
+          const wsUrl = `${wsBaseUrl}?player_id=${encodeURIComponent(player.id)}`;
           // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           const socket: any = new wsConstructor(wsUrl);
 
@@ -233,6 +292,14 @@ async function openTestWebSockets(roomId: string, players: TestPlayer[]): Promis
                 // 注: E2Eテストでは実際の復号化はuseComputationResultsフックが行う
                 // ここではsessionStorageモックが正常に動作することを確認するためのログ出力のみ
                 if (data.computation_type === "role_assignment" && data.target_player_id) {
+                  if (!global.roleAssignmentDeliveries) {
+                    global.roleAssignmentDeliveries = [];
+                  }
+                  global.roleAssignmentDeliveries.push({
+                    receiverPlayerId: player.id,
+                    targetPlayerId: String(data.target_player_id),
+                    batchId: typeof data.batch_id === "string" ? data.batch_id : undefined,
+                  });
                   console.log(
                     `   💾 [${player.name}] Role assignment result received for player_id: ${data.target_player_id}`,
                   );
@@ -428,12 +495,15 @@ export function createTestSetup(options?: TestSetupOptions) {
       console.log("✅ Crypto parameters loaded from server\n");
 
       console.log("✅ Setup completed!\n");
+      global.roleAssignmentDeliveries = [];
     },
 
     /**
      * 各テストの前に実行
      */
     beforeEach: async (): Promise<void> => {
+      roleShareBuffers.clear();
+      global.roleAssignmentDeliveries = [];
       // バッチリセット（エラーが出ても続行）
       try {
         await global.apiClient.resetBatch();

--- a/packages/nextjs/app/room/[id]/page.tsx
+++ b/packages/nextjs/app/room/[id]/page.tsx
@@ -48,6 +48,7 @@ export default function RoomPage({ params }: { params: { id: string } }) {
   const { websocketRef, websocketStatus, reconnectAttempt, connectWebSocket, disconnectWebSocket, sendMessage } =
     useGameWebSocket(params.id, addServerMessage, user?.username, {
       onReconnect: handleWebSocketReconnect,
+      playerId: user?.id,
     });
   const {
     isStarting,

--- a/packages/nextjs/app/room/[id]/page.tsx
+++ b/packages/nextjs/app/room/[id]/page.tsx
@@ -92,6 +92,7 @@ export default function RoomPage({ params }: { params: { id: string } }) {
           const updatedInfo = {
             ...existingInfo,
             playerRole: null as any,
+            werewolfTeammateIds: [],
             hasActed: false,
           };
           sessionStorage.setItem(`game_${roomId}_player_${user.id}`, JSON.stringify(updatedInfo));
@@ -267,6 +268,14 @@ export default function RoomPage({ params }: { params: { id: string } }) {
 
   const playersForView = (gameInfo ? gameInfo.players : roomInfo?.players) ?? [];
   const currentPlayer = playersForView.find(player => player.id === user?.id || player.name === user?.username);
+  const werewolfTeammateNames =
+    privateGameInfo?.playerRole === "Werewolf"
+      ? (privateGameInfo.werewolfTeammateIds ?? [])
+          .map(
+            teammateId => playersForView.find(player => String(player.id) === String(teammateId))?.name ?? teammateId,
+          )
+          .filter((name, index, self) => self.indexOf(name) === index)
+      : [];
   const isLobbyState = roomInfo?.status === "Open" || roomInfo?.status === "Ready";
   const isInProgress = roomInfo?.status === "InProgress";
   const isRoomActionDisabled = isInProgress || isLeavingRoom || isDeletingRoom;
@@ -415,6 +424,11 @@ export default function RoomPage({ params }: { params: { id: string } }) {
                     <span className="flex items-center gap-2 text-purple-600 bg-purple-50 px-3 py-1 rounded-full text-sm">
                       Your Role: {privateGameInfo?.playerRole ?? "Unknown"}
                     </span>
+                    {privateGameInfo?.playerRole === "Werewolf" && werewolfTeammateNames.length > 0 && (
+                      <span className="flex items-center gap-2 text-rose-700 bg-rose-50 px-3 py-1 rounded-full text-sm border border-rose-100">
+                        Werewolf Teammates: {werewolfTeammateNames.join(", ")}
+                      </span>
+                    )}
 
                     {isDebugMode && gameInfo.result === "InProgress" && (
                       <>
@@ -804,6 +818,7 @@ export default function RoomPage({ params }: { params: { id: string } }) {
           onClose={() => setShowNightAction(false)}
           roomId={gameInfo.room_id}
           myId={privateGameInfo?.playerId ?? ""}
+          werewolfTeammateIds={privateGameInfo?.werewolfTeammateIds}
         />
       )}
       {showVoteModal && gameInfo?.phase === "Voting" && (

--- a/packages/nextjs/components/game/NightActionModal.tsx
+++ b/packages/nextjs/components/game/NightActionModal.tsx
@@ -6,6 +6,7 @@ interface NightActionModalProps {
   players: Player[];
   role: Role;
   gameInfo: GameInfo;
+  werewolfTeammateIds?: string[];
   onSubmit: (targetPlayerId: string) => void;
   onClose: () => void;
   roomId: string;
@@ -16,6 +17,7 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
   players,
   role,
   gameInfo,
+  werewolfTeammateIds = [],
   onSubmit,
   onClose,
   roomId,
@@ -23,6 +25,7 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
 }) => {
   const [selectedPlayer, setSelectedPlayer] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const werewolfTeammateIdSet = new Set(werewolfTeammateIds);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -83,10 +86,14 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
   const selectablePlayers = players.filter(p => {
     if (p.is_dead === true) return false;
     if (p.id === myId) return false; // 自分自身は選択できない
-    // Note: Werewolf同士の識別情報はサーバーが保持していないため、
-    // 将来的にMPC計算結果として共有する必要がある
+    if (role === "Werewolf" && werewolfTeammateIdSet.has(p.id)) return false;
     return true;
   });
+
+  const werewolfTeammateNames =
+    role === "Werewolf"
+      ? players.filter(player => werewolfTeammateIdSet.has(player.id)).map(player => player.name)
+      : [];
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -94,6 +101,11 @@ const NightActionModal: React.FC<NightActionModalProps> = ({
         <h2 className="text-xl font-bold mb-4 text-indigo-900">
           {role === "Seer" ? "Select a target to divine" : role === "Werewolf" ? "Select a target to attack" : ""}
         </h2>
+        {role === "Werewolf" && werewolfTeammateNames.length > 0 && (
+          <p className="mb-3 text-sm text-red-700 bg-red-50 border border-red-100 rounded px-3 py-2">
+            Werewolf teammates: {werewolfTeammateNames.join(", ")}
+          </p>
+        )}
         <div className="space-y-2 mb-6">
           {selectablePlayers.map(player => (
             <div

--- a/packages/nextjs/hooks/useBackgroundNightAction.ts
+++ b/packages/nextjs/hooks/useBackgroundNightAction.ts
@@ -8,6 +8,16 @@ import { getPrivateGameInfo } from "~~/utils/privateGameInfoUtils";
 const pendingDivinationTargetKey = (roomId: string, dayCount: number): string =>
   `pending_divination_target_${roomId}_${dayCount}`;
 
+const divinationTargetIdByDayKey = (roomId: string, dayCount: number): string =>
+  `divination_target_${roomId}_${dayCount}`;
+
+const divinationTargetNameByDayKey = (roomId: string, dayCount: number): string =>
+  `divination_target_name_${roomId}_${dayCount}`;
+
+const latestDivinationTargetIdKey = (roomId: string): string => `divination_target_${roomId}`;
+
+const latestDivinationTargetNameKey = (roomId: string): string => `divination_target_name_${roomId}`;
+
 export const useBackgroundNightAction = () => {
   const handleBackgroundNightAction = useCallback(
     async (roomId: string, myId: string, players: Player[], username: string, gameInfo: GameInfo) => {
@@ -25,16 +35,22 @@ export const useBackgroundNightAction = () => {
         const isDummy = !hasSeerSelection;
 
         if (hasSeerSelection) {
-          const targetPlayerName = players.find(p => p.id === selectedTargetId)?.name || "Unknown";
-          localStorage.setItem(`divination_target_${roomId}`, selectedTargetId);
-          localStorage.setItem(`divination_target_name_${roomId}`, targetPlayerName);
+          const targetPlayerName = players.find(p => String(p.id) === String(selectedTargetId))?.name || "Unknown";
+
+          localStorage.setItem(divinationTargetIdByDayKey(roomId, dayCount), selectedTargetId);
+          localStorage.setItem(divinationTargetNameByDayKey(roomId, dayCount), targetPlayerName);
+
+          // 最新キーは既存参照との後方互換のために維持
+          localStorage.setItem(latestDivinationTargetIdKey(roomId), selectedTargetId);
+          localStorage.setItem(latestDivinationTargetNameKey(roomId), targetPlayerName);
+
           localStorage.removeItem(pendingDivinationTargetKey(roomId, dayCount));
           console.log(
             `Submitting synchronized divination for Seer ${myId}, day=${dayCount}, target=${selectedTargetId}`,
           );
         } else {
-          localStorage.removeItem(`divination_target_${roomId}`);
-          localStorage.removeItem(`divination_target_name_${roomId}`);
+          // ダミー送信時に最新キーを消すと、結果受信前に対象名が失われるケースがある。
+          // day単位キー/最新キーは保持して結果表示で参照する。
           console.log(`Submitting dummy divination for player ${myId}, day=${dayCount}`);
         }
 

--- a/packages/nextjs/hooks/useComputationResults.ts
+++ b/packages/nextjs/hooks/useComputationResults.ts
@@ -24,7 +24,10 @@ interface RoleAssignmentResult {
     nonce: string;
     node_id: number | string;
     required_shares: number | string;
+    schema_version?: string;
     share_encoding?: string;
+    role_share_encoding?: string;
+    werewolf_mates_mask_share_encoding?: string;
   };
   status: string;
 }
@@ -126,6 +129,28 @@ const decodeRoleName = (roleId: bigint): "Villager" | "Seer" | "Werewolf" => {
   return "Villager";
 };
 
+const decodeWerewolfTeammateIds = (
+  maskValue: bigint,
+  players: Array<{ id: string }> | undefined,
+  myPlayerId: string,
+  myRole: "Villager" | "Seer" | "Werewolf",
+): string[] => {
+  if (myRole !== "Werewolf" || !players || players.length === 0) {
+    return [];
+  }
+
+  const normalizedMask = normalizeFieldElement(maskValue);
+  const teammateIds: string[] = [];
+  for (let index = 0; index < players.length; index += 1) {
+    const bit = (normalizedMask >> BigInt(index)) & 1n;
+    if (bit !== 1n) continue;
+    const teammateId = players[index]?.id;
+    if (!teammateId || teammateId === myPlayerId) continue;
+    teammateIds.push(teammateId);
+  }
+  return teammateIds;
+};
+
 export const useComputationResults = (
   roomId: string,
   playerId: string,
@@ -137,9 +162,16 @@ export const useComputationResults = (
   const [winningJudgeResult, setWinningJudgeResult] = useState<WinningJudgeResult | null>(null);
   const [votingResult, setVotingResult] = useState<AnonymousVotingResult | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
-  const roleShareBuffersRef = useRef<Map<string, { requiredShares: number; sharesByNode: Map<number, bigint> }>>(
-    new Map(),
-  );
+  const roleShareBuffersRef = useRef<
+    Map<
+      string,
+      {
+        requiredShares: number;
+        roleSharesByNode: Map<number, bigint>;
+        werewolfMaskSharesByNode: Map<number, bigint>;
+      }
+    >
+  >(new Map());
   const completedRoleBatchRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -375,11 +407,15 @@ export const useComputationResults = (
                 node_id: nodeIdRaw,
                 required_shares: requiredSharesRaw,
                 share_encoding: shareEncoding,
+                role_share_encoding: roleShareEncodingRaw,
+                werewolf_mates_mask_share_encoding: werewolfMaskEncodingRaw,
               } = shareData;
 
               const nodeId = typeof nodeIdRaw === "string" ? Number(nodeIdRaw) : nodeIdRaw;
               const requiredShares =
                 typeof requiredSharesRaw === "string" ? Number(requiredSharesRaw) : requiredSharesRaw;
+              const roleShareEncoding = roleShareEncodingRaw ?? shareEncoding;
+              const werewolfMaskEncoding = werewolfMaskEncodingRaw ?? "player_index_bitmask_lsb0";
 
               if (!encrypted || !nonce || !Number.isFinite(nodeId)) {
                 throw new Error("Invalid encrypted role share payload");
@@ -387,8 +423,11 @@ export const useComputationResults = (
               if (!Number.isFinite(requiredShares) || requiredShares <= 0) {
                 throw new Error(`Invalid required_shares value: ${String(requiredSharesRaw)}`);
               }
-              if (shareEncoding && shareEncoding !== "bn254_fr_decimal_string") {
-                throw new Error(`Unsupported share encoding: ${shareEncoding}`);
+              if (roleShareEncoding && roleShareEncoding !== "bn254_fr_decimal_string") {
+                throw new Error(`Unsupported role share encoding: ${roleShareEncoding}`);
+              }
+              if (werewolfMaskEncoding && werewolfMaskEncoding !== "player_index_bitmask_lsb0") {
+                throw new Error(`Unsupported werewolf mask encoding: ${werewolfMaskEncoding}`);
               }
 
               const MPC_NODE_PUBLIC_KEYS = [
@@ -418,10 +457,31 @@ export const useComputationResults = (
               const decryptedString = decoder.decode(decryptedBinary);
 
               let roleShareString: string | null = null;
+              let werewolfMatesMaskShareString = "0";
               try {
-                const parsed = JSON.parse(decryptedString) as { role_share?: string };
+                const parsed = JSON.parse(decryptedString) as {
+                  role_share?: string;
+                  werewolf_mates_mask_share?: string;
+                  role_share_encoding?: string;
+                  werewolf_mates_mask_share_encoding?: string;
+                };
                 if (parsed && typeof parsed.role_share === "string") {
                   roleShareString = parsed.role_share;
+                }
+                if (parsed && typeof parsed.werewolf_mates_mask_share === "string") {
+                  werewolfMatesMaskShareString = parsed.werewolf_mates_mask_share;
+                }
+
+                if (parsed?.role_share_encoding && parsed.role_share_encoding !== "bn254_fr_decimal_string") {
+                  throw new Error(`Unsupported decrypted role share encoding: ${parsed.role_share_encoding}`);
+                }
+                if (
+                  parsed?.werewolf_mates_mask_share_encoding &&
+                  parsed.werewolf_mates_mask_share_encoding !== "player_index_bitmask_lsb0"
+                ) {
+                  throw new Error(
+                    `Unsupported decrypted werewolf mask encoding: ${parsed.werewolf_mates_mask_share_encoding}`,
+                  );
                 }
               } catch (parseError) {
                 throw new Error(
@@ -433,33 +493,48 @@ export const useComputationResults = (
               }
 
               const roleShare = normalizeFieldElement(BigInt(roleShareString));
+              const werewolfMatesMaskShare = normalizeFieldElement(BigInt(werewolfMatesMaskShareString));
               const existingBuffer = roleShareBuffersRef.current.get(batchKey) ?? {
                 requiredShares,
-                sharesByNode: new Map<number, bigint>(),
+                roleSharesByNode: new Map<number, bigint>(),
+                werewolfMaskSharesByNode: new Map<number, bigint>(),
               };
               existingBuffer.requiredShares = Math.max(existingBuffer.requiredShares, requiredShares);
-              if (existingBuffer.sharesByNode.has(nodeId)) {
+              if (existingBuffer.roleSharesByNode.has(nodeId)) {
                 break;
               }
-              existingBuffer.sharesByNode.set(nodeId, roleShare);
+              existingBuffer.roleSharesByNode.set(nodeId, roleShare);
+              existingBuffer.werewolfMaskSharesByNode.set(nodeId, werewolfMatesMaskShare);
               roleShareBuffersRef.current.set(batchKey, existingBuffer);
 
-              if (existingBuffer.sharesByNode.size < existingBuffer.requiredShares) {
+              if (existingBuffer.roleSharesByNode.size < existingBuffer.requiredShares) {
                 break;
               }
 
-              let combinedShare = 0n;
-              for (const share of existingBuffer.sharesByNode.values()) {
-                combinedShare = normalizeFieldElement(combinedShare + share);
+              let combinedRoleShare = 0n;
+              for (const share of existingBuffer.roleSharesByNode.values()) {
+                combinedRoleShare = normalizeFieldElement(combinedRoleShare + share);
               }
 
-              const roleName = decodeRoleName(combinedShare);
+              let combinedWerewolfMaskShare = 0n;
+              for (const share of existingBuffer.werewolfMaskSharesByNode.values()) {
+                combinedWerewolfMaskShare = normalizeFieldElement(combinedWerewolfMaskShare + share);
+              }
+
+              const roleName = decodeRoleName(combinedRoleShare);
+              const werewolfTeammateIds = decodeWerewolfTeammateIds(
+                combinedWerewolfMaskShare,
+                gameInfo?.players,
+                playerId,
+                roleName,
+              );
               let existingInfo = getPrivateGameInfo(roomId, playerId);
 
               if (!existingInfo) {
                 const initialInfo: PrivateGameInfo = {
                   playerId,
                   playerRole: null as any,
+                  werewolfTeammateIds: [],
                   hasActed: false,
                 };
                 setPrivateGameInfo(roomId, initialInfo);
@@ -468,6 +543,7 @@ export const useComputationResults = (
 
               const updatedInfo = updatePrivateGameInfo(roomId, playerId, {
                 playerRole: roleName as "Villager" | "Werewolf" | "Seer",
+                werewolfTeammateIds,
               });
 
               if (!updatedInfo) {
@@ -477,10 +553,17 @@ export const useComputationResults = (
               completedRoleBatchRef.current.add(batchKey);
               roleShareBuffersRef.current.delete(batchKey);
 
+              const werewolfTeammateNames = werewolfTeammateIds
+                .map(id => gameInfo?.players?.find((player: any) => String(player.id) === String(id))?.name || id)
+                .filter((name, index, self) => self.indexOf(name) === index);
+
               addMessage({
                 id: Date.now().toString(),
                 sender: "System",
-                message: `Your role has been assigned: ${roleName}`,
+                message:
+                  roleName === "Werewolf" && werewolfTeammateNames.length > 0
+                    ? `Your role has been assigned: ${roleName} (teammates: ${werewolfTeammateNames.join(", ")})`
+                    : `Your role has been assigned: ${roleName}`,
                 timestamp: new Date().toISOString(),
                 type: "system",
               });

--- a/packages/nextjs/hooks/useComputationResults.ts
+++ b/packages/nextjs/hooks/useComputationResults.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getFortuneTellerSecretKey, loadCryptoParams } from "~~/services/gameInputGenerator";
 import type { ChatMessage, PrivateGameInfo } from "~~/types/game";
 import { MPCEncryption } from "~~/utils/crypto/InputEncryption";
@@ -19,11 +19,13 @@ interface DivinationResult {
 }
 
 interface RoleAssignmentResult {
-  role_assignments: Array<{
-    player_id: string;
-    player_name: string;
-    role: string;
-  }>;
+  encrypted_role_share?: {
+    encrypted: string;
+    nonce: string;
+    node_id: number | string;
+    required_shares: number | string;
+    share_encoding?: string;
+  };
   status: string;
 }
 
@@ -110,6 +112,20 @@ const clearDivinationLogs = (roomId: string, playerId: string) => {
   localStorage.removeItem(getDivinationLogsKey(roomId, playerId));
 };
 
+const BN254_SCALAR_MODULUS = BigInt("21888242871839275222246405745257275088548364400416034343698204186575808495617");
+
+const normalizeFieldElement = (value: bigint): bigint => {
+  const reduced = value % BN254_SCALAR_MODULUS;
+  return reduced >= 0n ? reduced : reduced + BN254_SCALAR_MODULUS;
+};
+
+const decodeRoleName = (roleId: bigint): "Villager" | "Seer" | "Werewolf" => {
+  const normalized = normalizeFieldElement(roleId) % 3n;
+  if (normalized === 1n) return "Seer";
+  if (normalized === 2n) return "Werewolf";
+  return "Villager";
+};
+
 export const useComputationResults = (
   roomId: string,
   playerId: string,
@@ -121,6 +137,15 @@ export const useComputationResults = (
   const [winningJudgeResult, setWinningJudgeResult] = useState<WinningJudgeResult | null>(null);
   const [votingResult, setVotingResult] = useState<AnonymousVotingResult | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const roleShareBuffersRef = useRef<Map<string, { requiredShares: number; sharesByNode: Map<number, bigint> }>>(
+    new Map(),
+  );
+  const completedRoleBatchRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    roleShareBuffersRef.current.clear();
+    completedRoleBatchRef.current.clear();
+  }, [playerId, roomId]);
 
   useEffect(() => {
     if (!roomId || !playerId) return;
@@ -338,103 +363,102 @@ export const useComputationResults = (
           case "role_assignment":
             setRoleAssignmentResult(result.resultData);
 
-            // Role情報の復号処理
             try {
-              console.log("Starting role assignment decryption process");
-              console.log("Result data:", result.resultData);
-
-              // 暗号化されたRoleデータを取得
-              if (!result.resultData.encrypted_role) {
-                throw new Error("No encrypted role data in result");
+              const shareData = result.resultData?.encrypted_role_share;
+              if (!shareData) {
+                throw new Error("No encrypted role share found in role_assignment result");
               }
 
-              const { encrypted, nonce, node_id } = result.resultData.encrypted_role;
+              const {
+                encrypted,
+                nonce,
+                node_id: nodeIdRaw,
+                required_shares: requiredSharesRaw,
+                share_encoding: shareEncoding,
+              } = shareData;
 
-              if (!encrypted || !nonce || node_id === undefined) {
-                throw new Error("Invalid encrypted role data structure");
+              const nodeId = typeof nodeIdRaw === "string" ? Number(nodeIdRaw) : nodeIdRaw;
+              const requiredShares =
+                typeof requiredSharesRaw === "string" ? Number(requiredSharesRaw) : requiredSharesRaw;
+
+              if (!encrypted || !nonce || !Number.isFinite(nodeId)) {
+                throw new Error("Invalid encrypted role share payload");
+              }
+              if (!Number.isFinite(requiredShares) || requiredShares <= 0) {
+                throw new Error(`Invalid required_shares value: ${String(requiredSharesRaw)}`);
+              }
+              if (shareEncoding && shareEncoding !== "bn254_fr_decimal_string") {
+                throw new Error(`Unsupported share encoding: ${shareEncoding}`);
               }
 
-              // node_idからMPCノードの公開鍵を取得
               const MPC_NODE_PUBLIC_KEYS = [
                 process.env.NEXT_PUBLIC_MPC_NODE0_PUBLIC_KEY || "",
                 process.env.NEXT_PUBLIC_MPC_NODE1_PUBLIC_KEY || "",
                 process.env.NEXT_PUBLIC_MPC_NODE2_PUBLIC_KEY || "",
               ];
 
-              const sender_public_key = MPC_NODE_PUBLIC_KEYS[node_id];
+              const senderPublicKey = MPC_NODE_PUBLIC_KEYS[nodeId];
 
-              if (!sender_public_key) {
-                throw new Error(`MPC node ${node_id} public key not configured`);
+              if (!senderPublicKey) {
+                throw new Error(`MPC node ${nodeId} public key not configured`);
               }
 
-              // CryptoManagerで復号
               const cryptoManager = new CryptoManager(playerId);
-
               if (!cryptoManager.hasKeyPair()) {
-                throw new Error("No keypair found. Cannot decrypt role.");
+                throw new Error("No keypair found. Cannot decrypt role share.");
               }
 
-              console.log("Decrypting role with CryptoManager");
-              console.log("Encrypted (first 50 chars):", encrypted.substring(0, 50));
-              console.log("Nonce:", nonce);
-              console.log("Sender public key (first 20 chars):", sender_public_key.substring(0, 20));
+              const batchKey = `${result.batchId}:${playerId}`;
+              if (completedRoleBatchRef.current.has(batchKey)) {
+                break;
+              }
 
-              // バイナリデータとして復号
-              const decryptedBinary = cryptoManager.decryptBinary(encrypted, nonce, sender_public_key);
-
-              console.log("Role decrypted successfully. Binary length:", decryptedBinary.length);
-
-              // バイナリデータをUTF8文字列に変換
+              const decryptedBinary = cryptoManager.decryptBinary(encrypted, nonce, senderPublicKey);
               const decoder = new TextDecoder("utf-8");
               const decryptedString = decoder.decode(decryptedBinary);
 
-              console.log("Decrypted string:", decryptedString);
-
-              // JSONとしてパース（Vec<String>形式を想定）
-              let roleData: string[] | null = null;
+              let roleShareString: string | null = null;
               try {
-                roleData = JSON.parse(decryptedString);
-                console.log("Parsed role data:", roleData);
+                const parsed = JSON.parse(decryptedString) as { role_share?: string };
+                if (parsed && typeof parsed.role_share === "string") {
+                  roleShareString = parsed.role_share;
+                }
               } catch (parseError) {
-                console.error("Failed to parse role data as JSON:", parseError);
-                console.log("Raw data (first 200 chars):", decryptedString.substring(0, 200));
-                throw new Error("Invalid role data format");
+                throw new Error(
+                  `Invalid role share payload: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+                );
+              }
+              if (!roleShareString) {
+                throw new Error("Missing role_share in decrypted payload");
               }
 
-              // roleDataから実際のRole情報を抽出
-              // 修正後: 各プレイヤーには自分のRole IDのみが配列として送られる
-              // 例: ["0000000000000000000000000000000000000000000000000000000000000002"]
-              // 値はBigInt形式の16進数文字列で、0=Villager, 1=FortuneTeller, 2=Werewolf
-
-              if (!roleData || roleData.length === 0) {
-                throw new Error("Empty role data received");
-              }
-
-              // 配列の最初（唯一）の要素がこのプレイヤーのRole ID
-              const roleIdStr = roleData[0];
-
-              // 16進数文字列をBigIntとしてパース
-              const roleIdBigInt = BigInt("0x" + roleIdStr);
-              const roleId = roleIdBigInt % BigInt(3); // 0, 1, 2 のいずれか
-
-              const ROLE_MAPPING: Record<string, string> = {
-                "0": "Villager",
-                "1": "Seer",
-                "2": "Werewolf",
+              const roleShare = normalizeFieldElement(BigInt(roleShareString));
+              const existingBuffer = roleShareBuffersRef.current.get(batchKey) ?? {
+                requiredShares,
+                sharesByNode: new Map<number, bigint>(),
               };
+              existingBuffer.requiredShares = Math.max(existingBuffer.requiredShares, requiredShares);
+              if (existingBuffer.sharesByNode.has(nodeId)) {
+                break;
+              }
+              existingBuffer.sharesByNode.set(nodeId, roleShare);
+              roleShareBuffersRef.current.set(batchKey, existingBuffer);
 
-              const roleName = ROLE_MAPPING[roleId.toString()] || "Unknown";
+              if (existingBuffer.sharesByNode.size < existingBuffer.requiredShares) {
+                break;
+              }
 
-              console.log("Role ID:", roleId.toString(), "Role Name:", roleName);
+              let combinedShare = 0n;
+              for (const share of existingBuffer.sharesByNode.values()) {
+                combinedShare = normalizeFieldElement(combinedShare + share);
+              }
 
-              // 復号したRoleをprivateGameInfoに保存
-              // まず既存の情報を確認し、なければ初期化してから更新
+              const roleName = decodeRoleName(combinedShare);
               let existingInfo = getPrivateGameInfo(roomId, playerId);
 
               if (!existingInfo) {
-                console.log("PrivateGameInfo not found, initializing before role assignment");
                 const initialInfo: PrivateGameInfo = {
-                  playerId: playerId,
+                  playerId,
                   playerRole: null as any,
                   hasActed: false,
                 };
@@ -446,23 +470,22 @@ export const useComputationResults = (
                 playerRole: roleName as "Villager" | "Werewolf" | "Seer",
               });
 
-              if (updatedInfo) {
-                console.log("PrivateGameInfo updated successfully:", updatedInfo);
-              } else {
+              if (!updatedInfo) {
                 console.error("Failed to update PrivateGameInfo even after initialization attempt");
               }
+
+              completedRoleBatchRef.current.add(batchKey);
+              roleShareBuffersRef.current.delete(batchKey);
 
               addMessage({
                 id: Date.now().toString(),
                 sender: "System",
-                message: `Your role has been assigned: ${roleName} (from node ${node_id})`,
+                message: `Your role has been assigned: ${roleName}`,
                 timestamp: new Date().toISOString(),
                 type: "system",
               });
 
-              // Role割り当て完了イベントを発火
               window.dispatchEvent(new CustomEvent("roleAssignmentCompleted"));
-              console.log("Role assignment completion event dispatched");
             } catch (error) {
               console.error("Role decryption error:", error);
               addMessage({

--- a/packages/nextjs/hooks/useComputationResults.ts
+++ b/packages/nextjs/hooks/useComputationResults.ts
@@ -46,6 +46,16 @@ interface PersistedDivinationLog {
   message: string;
 }
 
+const divinationTargetIdByDayKey = (roomId: string, dayCount: number): string =>
+  `divination_target_${roomId}_${dayCount}`;
+
+const divinationTargetNameByDayKey = (roomId: string, dayCount: number): string =>
+  `divination_target_name_${roomId}_${dayCount}`;
+
+const latestDivinationTargetIdKey = (roomId: string): string => `divination_target_${roomId}`;
+
+const latestDivinationTargetNameKey = (roomId: string): string => `divination_target_name_${roomId}`;
+
 const getDivinationLogsKey = (roomId: string, playerId: string) => `divination_logs_${roomId}_${playerId}`;
 
 const parseTimestamp = (timestamp: string) => {
@@ -252,12 +262,27 @@ export const useComputationResults = (
                 }
 
                 // 占い対象のプレイヤー名を取得
-                const targetPlayerId = localStorage.getItem(`divination_target_${roomId}`);
-                const targetPlayerName = localStorage.getItem(`divination_target_name_${roomId}`);
+                const resultDayCountRaw = result.resultData?.day_count;
+                const resultDayCount =
+                  typeof resultDayCountRaw === "number"
+                    ? resultDayCountRaw
+                    : Number.parseInt(String(resultDayCountRaw ?? ""), 10);
+
+                const targetPlayerIdByDay = Number.isFinite(resultDayCount)
+                  ? localStorage.getItem(divinationTargetIdByDayKey(roomId, resultDayCount))
+                  : null;
+                const targetPlayerNameByDay = Number.isFinite(resultDayCount)
+                  ? localStorage.getItem(divinationTargetNameByDayKey(roomId, resultDayCount))
+                  : null;
+
+                const targetPlayerId = targetPlayerIdByDay || localStorage.getItem(latestDivinationTargetIdKey(roomId));
+                const targetPlayerName =
+                  targetPlayerNameByDay || localStorage.getItem(latestDivinationTargetNameKey(roomId));
+
                 let targetName = targetPlayerName || "Unknown";
                 // gameInfoから最新の名前も確認
                 if (targetPlayerId && gameInfo?.players) {
-                  const targetPlayer = gameInfo.players.find((p: any) => p.id === targetPlayerId);
+                  const targetPlayer = gameInfo.players.find((p: any) => String(p.id) === String(targetPlayerId));
                   if (targetPlayer) {
                     targetName = targetPlayer.name;
                   }

--- a/packages/nextjs/hooks/useGameInfo.ts
+++ b/packages/nextjs/hooks/useGameInfo.ts
@@ -82,6 +82,7 @@ export const useGameInfo = (
             const newPrivateInfo: PrivateGameInfo = {
               playerId: userId,
               playerRole: null as any, // Roleはまだ未決定
+              werewolfTeammateIds: [],
               hasActed: false,
             };
 

--- a/packages/nextjs/hooks/useGamePhase.ts
+++ b/packages/nextjs/hooks/useGamePhase.ts
@@ -175,10 +175,10 @@ export const useGamePhase = (
             );
 
             console.log(
-              `Player ${username} (ID: ${roleAssignmentData.privateInput.id}) initiating role assignment for ${playerCount} players`,
+              `Player ${username} (player_id: ${currentPlayer.id}, circuit_id: ${roleAssignmentData.privateInput.id}) initiating role assignment for ${playerCount} players`,
             );
 
-            await submitRoleAssignment(roomId, roleAssignmentData, playerCount);
+            await submitRoleAssignment(roomId, roleAssignmentData, playerCount, currentPlayer.id);
           } catch (error) {
             console.error("Role assignment process error:", error);
 

--- a/packages/nextjs/hooks/useGameWebSocket.ts
+++ b/packages/nextjs/hooks/useGameWebSocket.ts
@@ -133,9 +133,18 @@ export const useGameWebSocket = (
 
       if (isRoomEventEnvelope(parsed)) {
         const incomingEventId = parsed.event_id;
-        const lastEventId = lastEventIdRef.current;
+        let lastEventId = lastEventIdRef.current;
 
-        if (incomingEventId <= lastEventId) {
+        // Server restart or room event store reset can roll event_id back.
+        // In that case, treat incoming stream as a new sequence instead of dropping all events forever.
+        if (incomingEventId < lastEventId) {
+          console.warn(
+            `Detected room event_id reset (last=${lastEventId}, incoming=${incomingEventId}). Resetting cursor.`,
+          );
+          lastEventIdRef.current = 0;
+          persistLastEventId(roomId, 0);
+          lastEventId = 0;
+        } else if (incomingEventId === lastEventId) {
           return;
         }
 

--- a/packages/nextjs/hooks/useGameWebSocket.ts
+++ b/packages/nextjs/hooks/useGameWebSocket.ts
@@ -6,6 +6,7 @@ type WebSocketStatus = "disconnected" | "connecting" | "connected" | "reconnecti
 interface UseGameWebSocketOptions {
   onReconnect?: () => void | Promise<void>;
   onGapDetected?: (detail: { expectedEventId: number; receivedEventId: number }) => void | Promise<void>;
+  playerId?: string;
 }
 
 interface RoomEventEnvelope {
@@ -58,7 +59,7 @@ export const useGameWebSocket = (
   username?: string,
   options?: UseGameWebSocketOptions,
 ) => {
-  const { onReconnect, onGapDetected } = options ?? {};
+  const { onReconnect, onGapDetected, playerId } = options ?? {};
   const websocketRef = useRef<WebSocket | null>(null);
   const [websocketStatus, setWebsocketStatus] = useState<WebSocketStatus>("disconnected");
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
@@ -294,7 +295,15 @@ export const useGameWebSocket = (
     setWebsocketStatus(reconnectAttemptRef.current > 0 ? "reconnecting" : "connecting");
 
     const lastEventId = lastEventIdRef.current;
-    const resumeWsUrl = lastEventId > 0 ? `${wsUrl}?last_event_id=${encodeURIComponent(String(lastEventId))}` : wsUrl;
+    const params = new URLSearchParams();
+    if (lastEventId > 0) {
+      params.set("last_event_id", String(lastEventId));
+    }
+    if (playerId) {
+      params.set("player_id", playerId);
+    }
+    const query = params.toString();
+    const resumeWsUrl = query.length > 0 ? `${wsUrl}?${query}` : wsUrl;
 
     const ws = new WebSocket(resumeWsUrl);
     websocketRef.current = ws;
@@ -338,7 +347,7 @@ export const useGameWebSocket = (
       setWebsocketStatus("error");
       ws.close();
     };
-  }, [clearReconnectTimer, handleSocketMessage, roomId, scheduleReconnect, wsUrl]);
+  }, [clearReconnectTimer, handleSocketMessage, playerId, roomId, scheduleReconnect, wsUrl]);
   connectWebSocketRef.current = connectWebSocket;
 
   const disconnectWebSocket = useCallback(() => {

--- a/packages/nextjs/hooks/useRoleAssignment.ts
+++ b/packages/nextjs/hooks/useRoleAssignment.ts
@@ -16,7 +16,12 @@ export const useRoleAssignment = () => {
   ].filter((key): key is string => key != null);
 
   const submitRoleAssignment = useCallback(
-    async (roomId: string, roleAssignmentData: RoleAssignmentInput, alivePlayerCount: number) => {
+    async (
+      roomId: string,
+      roleAssignmentData: RoleAssignmentInput,
+      alivePlayerCount: number,
+      requesterPlayerId?: string,
+    ) => {
       setIsLoading(true);
       setError(null);
       try {
@@ -35,7 +40,7 @@ export const useRoleAssignment = () => {
         const requestBody = {
           proof_type: "RoleAssignment",
           data: {
-            user_id: String(roleAssignmentData.privateInput.id),
+            user_id: requesterPlayerId ? String(requesterPlayerId) : String(roleAssignmentData.privateInput.id),
             prover_count: alivePlayerCount,
             encrypted_data: encryptedRoleAssignment,
             public_key: roleAssignmentData.publicKey, // プレイヤーの公開鍵を追加

--- a/packages/nextjs/types/game.ts
+++ b/packages/nextjs/types/game.ts
@@ -53,6 +53,7 @@ export interface GameInfo {
 export interface PrivateGameInfo {
   playerId: string;
   playerRole: Role;
+  werewolfTeammateIds?: string[];
   hasActed: boolean; // アクションを実行済みか
 }
 

--- a/packages/nextjs/utils/privateGameInfoUtils.ts
+++ b/packages/nextjs/utils/privateGameInfoUtils.ts
@@ -74,6 +74,7 @@ export const initializePrivateGameInfo = (roomId: string, playerId: string): voi
   const initialPrivateInfo: PrivateGameInfo = {
     playerId,
     playerRole: null, // 役職は未決定状態で初期化
+    werewolfTeammateIds: [],
     hasActed: false,
   };
   setPrivateGameInfo(roomId, initialPrivateInfo);

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -661,7 +661,19 @@ impl Game {
                 batch.requests[existing_index] = request;
             }
         } else {
-            batch.requests.push(request);
+            let player_index_of = |user_id: &str| {
+                self.players
+                    .iter()
+                    .position(|player| player.id == user_id)
+                    .unwrap_or(usize::MAX)
+            };
+            let new_request_player_index = player_index_of(request.get_user_id());
+            let insert_pos = batch
+                .requests
+                .iter()
+                .position(|existing| player_index_of(existing.get_user_id()) > new_request_player_index)
+                .unwrap_or(batch.requests.len());
+            batch.requests.insert(insert_pos, request);
         }
 
         let batch_id = batch.batch_id.clone();
@@ -1156,7 +1168,10 @@ impl Game {
                             serde_json::json!({
                                 "encrypted_share_count": encrypted_shares.len(),
                                 "required_shares_by_player": required_shares_by_player.clone(),
+                                "schema_version": "role_assignment_share_v2",
                                 "share_encoding": "bn254_fr_decimal_string",
+                                "role_share_encoding": "bn254_fr_decimal_string",
+                                "werewolf_mates_mask_share_encoding": "player_index_bitmask_lsb0",
                                 "computed_at": chrono::Utc::now().to_rfc3339()
                             }),
                         );
@@ -1196,7 +1211,10 @@ impl Game {
                                     "nonce": nonce_b64,
                                     "node_id": node_id,
                                     "required_shares": required_shares,
-                                    "share_encoding": "bn254_fr_decimal_string"
+                                    "schema_version": "role_assignment_share_v2",
+                                    "share_encoding": "bn254_fr_decimal_string",
+                                    "role_share_encoding": "bn254_fr_decimal_string",
+                                    "werewolf_mates_mask_share_encoding": "player_index_bitmask_lsb0"
                                 },
                                 "status": "ready"
                             });

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -3,10 +3,7 @@ use crate::{
         state_hash::{compute_game_id, compute_proof_id},
         ProofType as ChainProofType,
     },
-    models::{
-        chat::{ChatMessage, ChatMessageType},
-        role::Role,
-    },
+    models::chat::{ChatMessage, ChatMessageType},
 };
 
 use super::player::Player;
@@ -1121,176 +1118,87 @@ impl Game {
                     CircuitEncryptedInputIdentifier::RoleAssignment(_items) => {
                         println!("RoleAssignment process is starting...");
 
-                        // ProofOutputからEncryptedSharesを取得
-                        if let Some(encrypted_shares) = output.shares {
-                            println!("Received {} encrypted role shares", encrypted_shares.len());
-
-                            // 各プレイヤーに個別に暗号化された役職データを配信
-                            for encrypted_share in encrypted_shares {
-                                let user_index_str = encrypted_share.user_id.clone();
-                                let node_id = encrypted_share.node_id;
-
-                                // user_idは配列のインデックス（文字列）なので、実際のプレイヤーIDに変換
-                                let user_index: usize = match user_index_str.parse() {
-                                    Ok(idx) => idx,
-                                    Err(e) => {
-                                        println!(
-                                            "ERROR: Failed to parse user_id '{}' as index: {}",
-                                            user_index_str, e
-                                        );
-                                        continue;
-                                    }
-                                };
-
-                                // インデックスからプレイヤーIDを取得
-                                let actual_player_id = if user_index < self.players.len() {
-                                    self.players[user_index].id.clone()
-                                } else {
-                                    println!(
-                                        "ERROR: Player index {} out of bounds (total players: {})",
-                                        user_index,
-                                        self.players.len()
-                                    );
-                                    continue;
-                                };
-
-                                println!(
-                                    "Converting user_index {} to player_id {}",
-                                    user_index, actual_player_id
-                                );
-
-                                // encrypted_dataは [nonce(24バイト) + ciphertext] の形式
-                                if encrypted_share.encrypted_data.len() < 24 {
-                                    println!(
-                                        "ERROR: Encrypted data too short for player {} (index {})",
-                                        actual_player_id, user_index
-                                    );
-                                    continue;
-                                }
-
-                                // nonceとciphertextを分離
-                                let nonce = &encrypted_share.encrypted_data[..24];
-                                let ciphertext = &encrypted_share.encrypted_data[24..];
-
-                                // Base64エンコード
-                                let nonce_b64 = base64::encode(nonce);
-                                let ciphertext_b64 = base64::encode(ciphertext);
-
-                                // サーバーは中継のみ - node_idを送信してクライアント側で公開鍵を解決
-                                let result_data = serde_json::json!({
-                                    "encrypted_role": {
-                                        "encrypted": ciphertext_b64,
-                                        "nonce": nonce_b64,
-                                        "node_id": node_id
-                                    },
-                                    "status": "ready"
-                                });
-
-                                println!(
-                                    "Sending encrypted role to player {} (index {}, from node {})",
-                                    actual_player_id, user_index, node_id
-                                );
-
-                                // 特定のプレイヤーにのみ送信（実際のプレイヤーIDを使用）
-                                if let Err(e) = app_state
-                                    .broadcast_computation_result(
-                                        &self.room_id,
-                                        "role_assignment",
-                                        result_data,
-                                        Some(actual_player_id.clone()), // 実際のプレイヤーIDを使用
-                                        &self.batch_request.batch_id,
-                                    )
-                                    .await
-                                {
-                                    println!(
-                                        "Failed to send encrypted role to player {}: {}",
-                                        actual_player_id, e
-                                    );
-                                }
-                            }
-
+                        let Some(encrypted_shares) = output.shares else {
+                            println!("RoleAssignment failed: no encrypted shares in proof output");
+                            self.batch_request.status = BatchStatus::Failed;
                             self.chat_log.add_system_message(
-                                "Roles have been assigned. Check your private information."
+                                "Role assignment failed: encrypted shares were missing."
                                     .to_string(),
                             );
-                        } else {
-                            // 後方互換性のため、古い実装も残す（デバッグモード用）
-                            println!("No encrypted shares found, using fallback role assignment");
+                            return;
+                        };
 
-                            let role_result: Vec<Fr> = match output.value {
-                                Some(bytes) => match CanonicalDeserialize::deserialize(&*bytes) {
-                                    Ok(state) => state,
-                                    Err(e) => {
-                                        println!("Failed to deserialize role_result: {}", e);
-                                        return;
-                                    }
-                                },
-                                None => {
-                                    println!("No output value found");
-                                    return;
-                                }
-                            };
+                        if encrypted_shares.is_empty() {
+                            println!("RoleAssignment failed: encrypted share list is empty");
+                            self.batch_request.status = BatchStatus::Failed;
+                            self.chat_log.add_system_message(
+                                "Role assignment failed: encrypted shares were empty."
+                                    .to_string(),
+                            );
+                            return;
+                        }
 
-                            let mut player_role: Option<Role> = None;
+                        println!("Received {} encrypted role shares", encrypted_shares.len());
 
-                            // role_resultをゲームの結果に反映
-                            let mut player_role_assignments = Vec::new();
-                            for (player, role) in self.players.iter_mut().zip(role_result.iter()) {
-                                let assigned_role = if *role == Fr::from(0u32) {
-                                    Some(Role::Villager)
-                                } else if *role == Fr::from(1u32) {
-                                    Some(Role::Seer)
-                                } else if *role == Fr::from(2u32) {
-                                    Some(Role::Werewolf)
-                                } else {
-                                    None
-                                };
+                        let mut required_shares_by_player = std::collections::HashMap::<
+                            String,
+                            usize,
+                        >::new();
+                        for share in &encrypted_shares {
+                            *required_shares_by_player
+                                .entry(share.user_id.clone())
+                                .or_insert(0) += 1;
+                        }
 
-                                player_role = assigned_role.clone();
+                        self.save_role_assignment_result(
+                            self.batch_request.batch_id.clone(),
+                            Vec::new(),
+                            serde_json::json!({
+                                "encrypted_share_count": encrypted_shares.len(),
+                                "required_shares_by_player": required_shares_by_player.clone(),
+                                "share_encoding": "bn254_fr_decimal_string",
+                                "computed_at": chrono::Utc::now().to_rfc3339()
+                            }),
+                        );
 
-                                if let Some(role) = assigned_role {
-                                    player_role_assignments.push(PlayerRoleAssignment {
-                                        player_id: player.id.clone(),
-                                        role: format!("{:?}", role),
-                                    });
-                                }
+                        for encrypted_share in encrypted_shares {
+                            let target_player_id = encrypted_share.user_id.clone();
+                            let node_id = encrypted_share.node_id;
+                            let required_shares = required_shares_by_player
+                                .get(&target_player_id)
+                                .copied()
+                                .unwrap_or_default();
+
+                            if !self.players.iter().any(|p| p.id == target_player_id) {
+                                println!(
+                                    "Skipping role share for unknown player_id={}",
+                                    target_player_id
+                                );
+                                continue;
                             }
 
-                            // 計算結果を保存
-                            self.save_role_assignment_result(
-                                self.batch_request.batch_id.clone(),
-                                player_role_assignments.clone(),
-                                serde_json::json!({
-                                    "raw_role_result": role_result.iter().map(|r| r.into_repr().to_string()).collect::<Vec<_>>(),
-                                    "computation_time": chrono::Utc::now().to_rfc3339()
-                                })
-                            );
+                            if encrypted_share.encrypted_data.len() < 24 {
+                                println!(
+                                    "Encrypted role share too short for player {} (node {})",
+                                    target_player_id, node_id
+                                );
+                                continue;
+                            }
 
-                            // self.chat_log.add_system_message(format!(
-                            //     "Roles have been assigned: {}. Starting the game.",
-                            //     self.players
-                            //         .iter()
-                            //         .map(|p| format!("{}: {:?}", p.name, p.role.as_ref().unwrap()))
-                            //         .collect::<Vec<_>>()
-                            //         .join(", ")
-                            // ));
-
-                            // 全プレイヤーに役職配布結果を通知
-                            let role_assignments: Vec<_> = self
-                                .players
-                                .iter()
-                                .map(|p| {
-                                    serde_json::json!({
-                                        "player_id": p.id,
-                                        "player_name": p.name,
-                                        "role": player_role
-                                    })
-                                })
-                                .collect();
+                            let nonce = &encrypted_share.encrypted_data[..24];
+                            let ciphertext = &encrypted_share.encrypted_data[24..];
+                            let nonce_b64 = base64::encode(nonce);
+                            let ciphertext_b64 = base64::encode(ciphertext);
 
                             let result_data = serde_json::json!({
-                                "role_assignments": role_assignments,
-                                "status": "completed"
+                                "encrypted_role_share": {
+                                    "encrypted": ciphertext_b64,
+                                    "nonce": nonce_b64,
+                                    "node_id": node_id,
+                                    "required_shares": required_shares,
+                                    "share_encoding": "bn254_fr_decimal_string"
+                                },
+                                "status": "ready"
                             });
 
                             if let Err(e) = app_state
@@ -1298,14 +1206,22 @@ impl Game {
                                     &self.room_id,
                                     "role_assignment",
                                     result_data,
-                                    None, // 全プレイヤーに送信
+                                    Some(target_player_id.clone()),
                                     &self.batch_request.batch_id,
                                 )
                                 .await
                             {
-                                println!("Failed to broadcast role assignment result: {}", e);
+                                println!(
+                                    "Failed to send encrypted role share to player {}: {}",
+                                    target_player_id, e
+                                );
                             }
                         }
+
+                        self.chat_log.add_system_message(
+                            "Roles have been assigned. Check your private information."
+                                .to_string(),
+                        );
                     }
                     CircuitEncryptedInputIdentifier::KeyPublicize(_items) => {
                         println!("KeyPublicize process is starting...");

--- a/packages/server/src/services/proof_job_service.rs
+++ b/packages/server/src/services/proof_job_service.rs
@@ -183,10 +183,23 @@ async fn process_job(
 
     let execution_result =
         crate::services::zk_proof::execute_batch_request(&job.batch_request).await;
-    let execution_error = execution_result.as_ref().err().cloned();
+    let mut execution_error = execution_result.as_ref().err().cloned();
 
     crate::services::zk_proof::store_precomputed_batch_result(batch_id.clone(), execution_result)
         .await;
+
+    if execution_error.is_none() {
+        let mut games = app_state.games.lock().await;
+        if let Some(game) = games.get_mut(&room_id) {
+            game.apply_proof_result_for_batch(&app_state, &job.batch_key, job.batch_request)
+                .await;
+        } else {
+            execution_error = Some(format!(
+                "Game not found while applying proof result: room_id={}",
+                room_id
+            ));
+        }
+    }
 
     let mut final_status_for_broadcast = None;
     {
@@ -222,12 +235,4 @@ async fn process_job(
             );
         }
     }
-
-    let mut games = app_state.games.lock().await;
-    let Some(game) = games.get_mut(&room_id) else {
-        return;
-    };
-
-    game.apply_proof_result_for_batch(&app_state, &job.batch_key, job.batch_request)
-        .await;
 }

--- a/packages/server/src/services/zk_proof.rs
+++ b/packages/server/src/services/zk_proof.rs
@@ -203,19 +203,16 @@ pub async fn check_status_with_retry(
 }
 
 pub async fn execute_batch_request(batch_request: &BatchRequest) -> BatchExecutionResult {
-    let mut sorted_requests = batch_request.requests.clone();
-    sorted_requests.sort_by(|a, b| {
-        let a_user_id = a.get_user_id().parse::<u32>().unwrap_or(u32::MAX);
-        let b_user_id = b.get_user_id().parse::<u32>().unwrap_or(u32::MAX);
-        a_user_id.cmp(&b_user_id)
-    });
+    // Keep canonical order from Game::add_request_to_batch.
+    // Re-sorting here can break index-based outputs (e.g. role shares / werewolf mate mask).
+    let ordered_requests = batch_request.requests.clone();
 
-    let identifier = try_convert_to_identifier(sorted_requests.clone())?;
+    let identifier = try_convert_to_identifier(ordered_requests.clone())?;
 
     let output_type = match &identifier {
         CircuitEncryptedInputIdentifier::RoleAssignment(_) => {
             let mut player_pubkeys = Vec::new();
-            for request in &sorted_requests {
+            for request in &ordered_requests {
                 if let Some(pubkey) = request.get_public_key() {
                     player_pubkeys.push(zk_mpc_node::UserPublicKey {
                         user_id: request.get_user_id().to_string(),

--- a/packages/server/src/utils/websocket.rs
+++ b/packages/server/src/utils/websocket.rs
@@ -148,71 +148,78 @@ pub async fn handle_socket(
     let state_for_receive = state.clone();
     let receive_task = tokio::spawn(async move {
         while let Some(Ok(msg)) = receiver.next().await {
-            if let Message::Text(text) = msg {
-                // JSONメッセージをパースを試みる
-                match serde_json::from_str::<WebSocketMessage>(&text) {
-                    Ok(mut ws_message) => {
-                        // player_idが空の場合はデフォルトIDを使用
-                        if ws_message.player_id.trim().is_empty() {
-                            ws_message.player_id = default_player_id.clone();
-                        }
-                        ws_message.room_id = room_id_for_receive.clone();
-
-                        // チャットメッセージに変換して保存
-                        let chat_message = ws_message.to_chat_message();
-                        if let Err(e) = state_for_receive
-                            .save_chat_message(&room_id_for_receive, chat_message)
-                            .await
-                        {
-                            eprintln!("Error saving chat message: {}", e);
-                        }
-
-                        let payload = match serde_json::to_value(&ws_message) {
-                            Ok(payload) => payload,
-                            Err(e) => {
-                                eprintln!("Error converting websocket message to json: {}", e);
-                                continue;
+            match msg {
+                Message::Text(text) => {
+                    // JSONメッセージをパースを試みる
+                    match serde_json::from_str::<WebSocketMessage>(&text) {
+                        Ok(mut ws_message) => {
+                            // player_idが空の場合はデフォルトIDを使用
+                            if ws_message.player_id.trim().is_empty() {
+                                ws_message.player_id = default_player_id.clone();
                             }
-                        };
-                        info!(
-                            "Received valid message in room {}: {:?}",
-                            room_id_for_receive, ws_message
-                        );
-                        if let Err(e) = state_for_receive
-                            .publish_room_event(&room_id_for_receive, payload)
-                            .await
-                        {
-                            eprintln!("Error sending message: {}", e);
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        // 不正なメッセージフォーマットの場合、エラーメッセージを送信
-                        let error_message = WebSocketMessage {
-                            message_type: "error".to_string(),
-                            player_id: "system".to_string(),
-                            player_name: "System".to_string(),
-                            content: format!("メッセージのフォーマットが不正です: {}", e),
-                            timestamp: chrono::Local::now().to_rfc3339(),
-                            room_id: room_id_for_receive.clone(),
-                        };
+                            ws_message.room_id = room_id_for_receive.clone();
 
-                        info!("Sending error message: {:?}", error_message);
-                        let error_payload = match serde_json::to_value(&error_message) {
-                            Ok(payload) => payload,
-                            Err(err) => {
-                                eprintln!("Error converting error message to json: {}", err);
-                                continue;
+                            // チャットメッセージに変換して保存
+                            let chat_message = ws_message.to_chat_message();
+                            if let Err(e) = state_for_receive
+                                .save_chat_message(&room_id_for_receive, chat_message)
+                                .await
+                            {
+                                eprintln!("Error saving chat message: {}", e);
                             }
-                        };
-                        if let Err(err) = state_for_receive
-                            .publish_room_event(&room_id_for_receive, error_payload)
-                            .await
-                        {
-                            eprintln!("Error sending error message: {}", err);
+
+                            let payload = match serde_json::to_value(&ws_message) {
+                                Ok(payload) => payload,
+                                Err(e) => {
+                                    eprintln!("Error converting websocket message to json: {}", e);
+                                    continue;
+                                }
+                            };
+                            info!(
+                                "Received valid message in room {}: {:?}",
+                                room_id_for_receive, ws_message
+                            );
+                            if let Err(e) = state_for_receive
+                                .publish_room_event(&room_id_for_receive, payload)
+                                .await
+                            {
+                                eprintln!("Error sending message: {}", e);
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            // 不正なメッセージフォーマットの場合、エラーメッセージを送信
+                            let error_message = WebSocketMessage {
+                                message_type: "error".to_string(),
+                                player_id: "system".to_string(),
+                                player_name: "System".to_string(),
+                                content: format!("メッセージのフォーマットが不正です: {}", e),
+                                timestamp: chrono::Local::now().to_rfc3339(),
+                                room_id: room_id_for_receive.clone(),
+                            };
+
+                            info!("Sending error message: {:?}", error_message);
+                            let error_payload = match serde_json::to_value(&error_message) {
+                                Ok(payload) => payload,
+                                Err(err) => {
+                                    eprintln!("Error converting error message to json: {}", err);
+                                    continue;
+                                }
+                            };
+                            if let Err(err) = state_for_receive
+                                .publish_room_event(&room_id_for_receive, error_payload)
+                                .await
+                            {
+                                eprintln!("Error sending error message: {}", err);
+                            }
                         }
                     }
                 }
+                Message::Close(_) => {
+                    info!("WebSocket close received for room {}", room_id_for_receive);
+                    break;
+                }
+                _ => {}
             }
         }
     });
@@ -238,7 +245,12 @@ pub async fn handle_socket(
             }
             info!("Sending message in room {}: {:?}", room_id_for_send, msg);
             if let Err(e) = sender.send(msg).await {
-                eprintln!("Error sending message: {}", e);
+                let err_text = e.to_string();
+                if err_text.contains("closed connection") {
+                    info!("WebSocket already closed for room {}. closing sender task.", room_id_for_send);
+                } else {
+                    eprintln!("Error sending message: {}", err_text);
+                }
                 break;
             }
         }

--- a/packages/server/src/utils/websocket.rs
+++ b/packages/server/src/utils/websocket.rs
@@ -49,6 +49,24 @@ struct ComputationResultNotification {
 pub struct WebSocketConnectQuery {
     #[serde(default)]
     last_event_id: Option<u64>,
+    #[serde(default)]
+    player_id: Option<String>,
+}
+
+fn should_send_event_to_player(
+    payload: &serde_json::Value,
+    connected_player_id: Option<&str>,
+) -> bool {
+    let message_type = payload.get("message_type").and_then(|v| v.as_str());
+    if message_type != Some("computation_result") {
+        return true;
+    }
+
+    let target_player_id = payload.get("target_player_id").and_then(|v| v.as_str());
+    match target_player_id {
+        Some(target) => connected_player_id.is_some_and(|connected| connected == target),
+        None => true,
+    }
 }
 
 impl WebSocketMessage {
@@ -81,12 +99,22 @@ pub async fn handler(
             state.clone(),
             room_id,
             query.last_event_id.unwrap_or(0),
+            query.player_id.clone(),
         )
     })
 }
 
-pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String, last_event_id: u64) {
-    info!("New WebSocket connection established for room: {}", room_id);
+pub async fn handle_socket(
+    ws: WebSocket,
+    state: AppState,
+    room_id: String,
+    last_event_id: u64,
+    connected_player_id: Option<String>,
+) {
+    info!(
+        "New WebSocket connection established for room: {} (player_id={:?})",
+        room_id, connected_player_id
+    );
     let tx = state.get_or_create_room_channel(&room_id).await;
 
     let (mut sender, mut receiver) = ws.split();
@@ -100,6 +128,9 @@ pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String, last
         .replay_room_events_since(&room_id, last_event_id)
         .await;
     for event in replay_events {
+        if !should_send_event_to_player(&event.payload, connected_player_id.as_deref()) {
+            continue;
+        }
         match serde_json::to_string(&event) {
             Ok(message_text) => {
                 if sender
@@ -187,8 +218,24 @@ pub async fn handle_socket(ws: WebSocket, state: AppState, room_id: String, last
     });
 
     let room_id_for_send = room_id_for_send.clone();
+    let connected_player_id_for_send = connected_player_id.clone();
     let send_task = tokio::spawn(async move {
         while let Ok(msg) = rx.recv().await {
+            if let Message::Text(ref text) = msg {
+                match serde_json::from_str::<crate::state::RoomEventEnvelope>(text) {
+                    Ok(event) => {
+                        if !should_send_event_to_player(
+                            &event.payload,
+                            connected_player_id_for_send.as_deref(),
+                        ) {
+                            continue;
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Error parsing room event envelope: {}", e);
+                    }
+                }
+            }
             info!("Sending message in room {}: {:?}", room_id_for_send, msg);
             if let Err(e) = sender.send(msg).await {
                 eprintln!("Error sending message: {}", e);

--- a/packages/zk-mpc-node/src/node.rs
+++ b/packages/zk-mpc-node/src/node.rs
@@ -11,7 +11,7 @@ use mpc_algebra::{AdditivePairingShare, MpcPairingEngine, Reveal};
 use mpc_algebra_wasm::{CircuitEncryptedInputIdentifier, CircuitProfile};
 use mpc_circuits::CircuitFactory;
 use mpc_net::multi::MPCNetConnection;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::iter::zip;
 use std::path::PathBuf;
@@ -25,8 +25,18 @@ type MPCProvingKey =
 
 #[derive(Serialize)]
 struct RoleSharePayload<'a> {
+    schema_version: &'static str,
     role_share: &'a str,
-    share_encoding: &'static str,
+    role_share_encoding: &'static str,
+    werewolf_mates_mask_share: &'a str,
+    werewolf_mates_mask_share_encoding: &'static str,
+}
+
+#[derive(Deserialize)]
+struct RoleOutputV2 {
+    role_share: String,
+    #[serde(default)]
+    werewolf_mates_mask_share: Option<String>,
 }
 
 #[derive(Clone)]
@@ -359,11 +369,47 @@ impl<IO: AsyncRead + AsyncWrite + Unpin + Send + 'static> Node<IO> {
         let output_str = std::str::from_utf8(output)
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
 
-        let parsed_role_shares = serde_json::from_str::<Vec<String>>(output_str).ok();
+        let parsed_role_outputs_v2 = serde_json::from_str::<Vec<RoleOutputV2>>(output_str).ok();
+        let parsed_role_shares_v1 = serde_json::from_str::<Vec<String>>(output_str).ok();
 
         // 各シェアを暗号化
         let mut encrypted_shares = Vec::new();
-        if let Some(role_shares) = parsed_role_shares {
+        if let Some(role_outputs) = parsed_role_outputs_v2 {
+            if role_outputs.len() < pubkeys.len() {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "role share length mismatch: got {}, expected at least {}",
+                    role_outputs.len(),
+                    pubkeys.len()
+                ))));
+            }
+            for (role_output, pubkey) in zip(role_outputs.iter(), pubkeys.iter()) {
+                let share_payload = RoleSharePayload {
+                    schema_version: "role_assignment_share_v2",
+                    role_share: &role_output.role_share,
+                    role_share_encoding: "bn254_fr_decimal_string",
+                    werewolf_mates_mask_share: role_output
+                        .werewolf_mates_mask_share
+                        .as_deref()
+                        .unwrap_or("0"),
+                    werewolf_mates_mask_share_encoding: "player_index_bitmask_lsb0",
+                };
+                let share_bytes = serde_json::to_vec(&share_payload)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+                let encrypted = self
+                    .key_manager
+                    .encrypt_share(&share_bytes, &pubkey.public_key)
+                    .await
+                    .map_err(|e| -> Box<dyn std::error::Error + Send> { Box::new(e) })?;
+                encrypted_shares.push(EncryptedShare {
+                    node_id: self.id,
+                    user_id: pubkey.user_id.clone(),
+                    encrypted_data: encrypted,
+                });
+            }
+            return Ok(encrypted_shares);
+        }
+
+        if let Some(role_shares) = parsed_role_shares_v1 {
             if role_shares.len() < pubkeys.len() {
                 return Err(Box::new(std::io::Error::other(format!(
                     "role share length mismatch: got {}, expected at least {}",
@@ -373,8 +419,11 @@ impl<IO: AsyncRead + AsyncWrite + Unpin + Send + 'static> Node<IO> {
             }
             for (role_share, pubkey) in zip(role_shares.iter(), pubkeys.iter()) {
                 let share_payload = RoleSharePayload {
+                    schema_version: "role_assignment_share_v2",
                     role_share,
-                    share_encoding: "bn254_fr_decimal_string",
+                    role_share_encoding: "bn254_fr_decimal_string",
+                    werewolf_mates_mask_share: "0",
+                    werewolf_mates_mask_share_encoding: "player_index_bitmask_lsb0",
                 };
                 let share_bytes = serde_json::to_vec(&share_payload)
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;

--- a/packages/zk-mpc-node/src/node.rs
+++ b/packages/zk-mpc-node/src/node.rs
@@ -11,6 +11,7 @@ use mpc_algebra::{AdditivePairingShare, MpcPairingEngine, Reveal};
 use mpc_algebra_wasm::{CircuitEncryptedInputIdentifier, CircuitProfile};
 use mpc_circuits::CircuitFactory;
 use mpc_net::multi::MPCNetConnection;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::iter::zip;
 use std::path::PathBuf;
@@ -21,6 +22,12 @@ use zk_mpc::groth16::create_random_proof;
 type LocalProvingKey = ProvingKey<ark_bn254::Bn254>;
 type MPCProvingKey =
     ProvingKey<MpcPairingEngine<ark_bn254::Bn254, AdditivePairingShare<ark_bn254::Bn254>>>;
+
+#[derive(Serialize)]
+struct RoleSharePayload<'a> {
+    role_share: &'a str,
+    share_encoding: &'static str,
+}
 
 #[derive(Clone)]
 struct Groth16Setup {
@@ -348,38 +355,53 @@ impl<IO: AsyncRead + AsyncWrite + Unpin + Send + 'static> Node<IO> {
         output: &[u8],
         pubkeys: &[UserPublicKey],
     ) -> Result<Vec<EncryptedShare>, Box<dyn std::error::Error + Send>> {
-        // outputをJSONとしてパース（RoleAssignmentの場合は配列）
+        // outputをJSONとしてパース（RoleAssignmentの場合は share 配列）
         let output_str = std::str::from_utf8(output)
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
 
-        // JSON配列として解釈を試みる
-        let shares: Vec<Vec<u8>> =
-            if let Ok(role_array) = serde_json::from_str::<Vec<String>>(output_str) {
-                // RoleAssignmentの場合：各プレイヤーに対応するインデックスの値のみを送る
-                role_array
-                    .iter()
-                    .take(pubkeys.len())
-                    .map(|role| serde_json::to_vec(&vec![role]))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?
-            } else {
-                // その他の場合：全データを各プレイヤーに送る（従来の動作）
-                vec![output.to_vec(); pubkeys.len()]
-            };
-
-        let pubkeys_vec = pubkeys.to_vec();
+        let parsed_role_shares = serde_json::from_str::<Vec<String>>(output_str).ok();
 
         // 各シェアを暗号化
         let mut encrypted_shares = Vec::new();
-        for (share, pubkey) in zip(shares, pubkeys_vec) {
+        if let Some(role_shares) = parsed_role_shares {
+            if role_shares.len() < pubkeys.len() {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "role share length mismatch: got {}, expected at least {}",
+                    role_shares.len(),
+                    pubkeys.len()
+                ))));
+            }
+            for (role_share, pubkey) in zip(role_shares.iter(), pubkeys.iter()) {
+                let share_payload = RoleSharePayload {
+                    role_share,
+                    share_encoding: "bn254_fr_decimal_string",
+                };
+                let share_bytes = serde_json::to_vec(&share_payload)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+                let encrypted = self
+                    .key_manager
+                    .encrypt_share(&share_bytes, &pubkey.public_key)
+                    .await
+                    .map_err(|e| -> Box<dyn std::error::Error + Send> { Box::new(e) })?;
+                encrypted_shares.push(EncryptedShare {
+                    node_id: self.id,
+                    user_id: pubkey.user_id.clone(),
+                    encrypted_data: encrypted,
+                });
+            }
+            return Ok(encrypted_shares);
+        }
+
+        // その他の場合：全データを各プレイヤーに送る（従来の動作）
+        for pubkey in pubkeys.iter() {
             let encrypted = self
                 .key_manager
-                .encrypt_share(&share, &pubkey.public_key)
+                .encrypt_share(output, &pubkey.public_key)
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send> { Box::new(e) })?;
             encrypted_shares.push(EncryptedShare {
                 node_id: self.id,
-                user_id: pubkey.user_id,
+                user_id: pubkey.user_id.clone(),
                 encrypted_data: encrypted,
             });
         }


### PR DESCRIPTION
# RoleAssignment share delivery hardening and websocket stabilization

## 概要(日本語)
RoleAssignmentの非公開配信フローを強化し、サーバー/ノードが平文役職を扱わない構成に寄せました。あわせて、占い結果の対象プレイヤー解決、狼仲間情報の復元/表示、WebSocket再接続時の取りこぼしと切断ログノイズを修正しています。

## Summary (English)
This PR hardens the private RoleAssignment share delivery flow so plaintext roles are not handled by server/node paths. It also fixes divination target resolution, adds werewolf teammate reconstruction/display, and improves WebSocket reliability by handling event-id resets and closed-connection noise.

## Changes
- Enforced encrypted share-based RoleAssignment delivery path and tightened player targeting.
- Extended RoleAssignment payload/processing to carry werewolf teammate mask shares and client-side reconstruction.
- Fixed divination log target-player resolution to avoid `Unknown` labels.
- Updated server batch/proof processing flow ordering and request ordering consistency for index-based outputs.
- Added/updated E2E coverage for `n5-w2` focus scenarios and RoleAssignment behavior.
- Improved WebSocket behavior:
  - include `player_id` in WS connection query for targeted computation events,
  - recover from room `event_id` reset after server restart,
  - suppress noisy closed-connection send errors.

## Related
- None
