### PR TITLE
Fix/game time progression

### DIFF
--- a/packages/mpc-circuits/src/traits/circuits.rs
+++ b/packages/mpc-circuits/src/traits/circuits.rs
@@ -1183,6 +1183,142 @@ impl KeyPublicizeCircuit<MpcField<Fr>> {
     }
 }
 
+impl RoleAssignmentCircuit<Fr> {
+    // Vec<Fr> は各プレイヤーの役職IDを表す。0が村人、1が占い師、2が人狼など。
+    pub fn calculate_output(&self) -> Vec<Fr> {
+        let num_players = self.private_input.len();
+        if num_players == 0 {
+            return Vec::new();
+        }
+
+        let grouping_parameter = &self.public_input.grouping_parameter;
+        let tau_matrix = self.public_input.tau_matrix.clone();
+        let matrix_size = tau_matrix.nrows();
+
+        let shuffle_matrices = self
+            .private_input
+            .iter()
+            .map(|input| input.shuffle_matrices.clone())
+            .collect::<Vec<_>>();
+        let inverse_shuffle_matrices = self
+            .private_input
+            .iter()
+            .rev()
+            .map(|input| input.shuffle_matrices.transpose())
+            .collect::<Vec<_>>();
+
+        let matrix_m = shuffle_matrices
+            .iter()
+            .skip(1)
+            .fold(shuffle_matrices[0].clone(), |acc, x| acc * x);
+        let inverse_matrix_m = inverse_shuffle_matrices
+            .iter()
+            .skip(1)
+            .fold(inverse_shuffle_matrices[0].clone(), |acc, x| acc * x);
+
+        // rho = M^-1 * tau * M
+        let rho = inverse_matrix_m * &tau_matrix * &matrix_m;
+
+        let mut rho_sequence = Vec::with_capacity(num_players);
+        let mut current_rho = rho.clone();
+        for _ in 0..num_players {
+            rho_sequence.push(current_rho.clone());
+            current_rho *= rho.clone();
+        }
+
+        let role_id_lookup = (0..matrix_size)
+            .map(|idx| match grouping_parameter.get_corresponding_role(idx) {
+                Role::Villager => Fr::from(0u32),
+                Role::FortuneTeller => Fr::from(1u32),
+                Role::Werewolf => Fr::from(2u32),
+            })
+            .collect::<Vec<_>>();
+
+        let stair_vector = na::DVector::from(
+            (0..matrix_size)
+                .map(|idx| Fr::from(idx as u32))
+                .collect::<Vec<_>>(),
+        );
+
+        let mut output_vec = Vec::with_capacity(num_players);
+        for player_id in 0..num_players {
+            let mut unit_vec = na::DVector::<Fr>::zeros(matrix_size);
+            unit_vec[player_id] = Fr::one();
+
+            // rho^1(i), rho^2(i), ..., rho^n(i) を index 値へ変換
+            let mut role_path = Vec::with_capacity(num_players);
+            for rho_i in &rho_sequence {
+                let moved = rho_i * unit_vec.clone();
+                role_path.push(moved.dot(&stair_vector));
+            }
+
+            // role_val = max(role_path)
+            let mut role_value = role_path[0];
+            for candidate in role_path.iter().skip(1) {
+                if role_value < *candidate {
+                    role_value = *candidate;
+                }
+            }
+
+            // role_val (公開インデックス) -> 役職ID(0/1/2)
+            let mut role_id = Fr::zero();
+            for (idx, mapped_role_id) in role_id_lookup.iter().enumerate() {
+                if (role_value - Fr::from(idx as u32)).is_zero() {
+                    role_id = *mapped_role_id;
+                    break;
+                }
+            }
+            output_vec.push(role_id);
+        }
+
+        output_vec
+    }
+
+    pub fn calculate_output_with_werewolf_mates_mask(
+        &self,
+    ) -> Vec<RoleAssignmentPlayerShares<Fr>> {
+        let role_shares = self.calculate_output();
+        let num_players = role_shares.len();
+        if num_players == 0 {
+            return Vec::new();
+        }
+
+        let werewolf_flags = role_shares
+            .iter()
+            .map(|role_share| {
+                if (*role_share - Fr::from(2u32)).is_zero() {
+                    Fr::one()
+                } else {
+                    Fr::zero()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut outputs = Vec::with_capacity(num_players);
+        for i in 0..num_players {
+            let mut teammate_mask_share = Fr::zero();
+            let self_is_werewolf = werewolf_flags[i];
+
+            for j in 0..num_players {
+                if i == j {
+                    continue;
+                }
+
+                let bit = 1u32.checked_shl(j as u32).unwrap_or(0);
+                let weight = Fr::from(bit);
+                teammate_mask_share += weight * self_is_werewolf * werewolf_flags[j];
+            }
+
+            outputs.push(RoleAssignmentPlayerShares {
+                role_share: role_shares[i],
+                werewolf_mates_mask_share: teammate_mask_share,
+            });
+        }
+
+        outputs
+    }
+}
+
 impl RoleAssignmentCircuit<MpcField<Fr>> {
     // Vec<MpcField<Fr>> は各プレイヤーの役職IDを表す。0が村人、1が占い師、2が人狼など。
     pub fn calculate_output(&self) -> Vec<MpcField<Fr>> {

--- a/packages/mpc-circuits/tests/role_assignment_groth16_local.rs
+++ b/packages/mpc-circuits/tests/role_assignment_groth16_local.rs
@@ -2,10 +2,13 @@ use std::collections::BTreeMap;
 
 use ark_bn254::{Bn254, Fr};
 use ark_crypto_primitives::CommitmentScheme;
+use ark_ff::PrimeField;
 use ark_groth16::{create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
 use ark_std::test_rng;
-use mpc_algebra_wasm::{calc_shuffle_matrix, GroupingParameter, Role as GroupingRole};
+use mpc_algebra_wasm::{
+    calc_shuffle_matrix, generate_individual_shuffle_matrix, GroupingParameter, Role as GroupingRole,
+};
 use mpc_circuits::{RoleAssignmentCircuit, RoleAssignmentPrivateInput, RoleAssignmentPublicInput};
 use zk_mpc::circuits::LocalOrMPC;
 
@@ -28,13 +31,12 @@ fn build_role_assignment_circuit(num_players: usize, werewolf_count: usize) -> R
     let mut rng = test_rng();
     let grouping_parameter = build_grouping_parameter(num_players, werewolf_count);
     let tau_matrix = grouping_parameter.generate_tau_matrix::<Fr>();
-    let matrix_size = tau_matrix.nrows();
-    let identity = nalgebra::DMatrix::<Fr>::identity(matrix_size, matrix_size);
+    let num_groups = grouping_parameter.get_num_groups();
 
     let private_input = (0..num_players)
         .map(|id| RoleAssignmentPrivateInput::<Fr> {
             id,
-            shuffle_matrices: identity.clone(),
+            shuffle_matrices: generate_individual_shuffle_matrix::<Fr, _>(num_players, num_groups, &mut rng),
             randomness: <Fr as LocalOrMPC<Fr>>::PedersenRandomness::default(),
             player_randomness: Fr::from((id + 1) as u64),
         })
@@ -66,11 +68,38 @@ fn build_public_inputs(circuit: &RoleAssignmentCircuit<Fr>) -> Vec<Fr> {
     tau.iter().copied().collect()
 }
 
+fn fr_to_u32(value: Fr) -> u32 {
+    let repr = value.into_repr();
+    let limbs = repr.as_ref();
+    assert!(
+        limbs.iter().skip(1).all(|&limb| limb == 0),
+        "Fr value is too large for u32 conversion: {:?}",
+        limbs
+    );
+    u32::try_from(limbs[0]).expect("Fr value does not fit into u32")
+}
+
+fn role_to_role_id(role: GroupingRole) -> u32 {
+    match role {
+        GroupingRole::Villager => 0,
+        GroupingRole::FortuneTeller => 1,
+        GroupingRole::Werewolf => 2,
+    }
+}
+
+fn decode_player_mask(mask: u32, num_players: usize) -> Vec<usize> {
+    (0..num_players)
+        .filter(|&idx| (mask & (1u32 << idx)) != 0)
+        .collect::<Vec<_>>()
+}
+
 fn print_role_assignment_outputs(num_players: usize, werewolf_count: usize) {
+    let mut rng = test_rng();
     let grouping_parameter = build_grouping_parameter(num_players, werewolf_count);
-    let matrix_size = grouping_parameter.get_num_players() + grouping_parameter.get_num_groups();
-    let identity = nalgebra::DMatrix::<Fr>::identity(matrix_size, matrix_size);
-    let shuffle_matrices = (0..num_players).map(|_| identity.clone()).collect::<Vec<_>>();
+    let num_groups = grouping_parameter.get_num_groups();
+    let shuffle_matrices = (0..num_players)
+        .map(|_| generate_individual_shuffle_matrix::<Fr, _>(num_players, num_groups, &mut rng))
+        .collect::<Vec<_>>();
 
     println!("=== RoleAssignment local output: n{}-w{} ===", num_players, werewolf_count);
     for id in 0..num_players {
@@ -139,6 +168,152 @@ fn role_assignment_local_constraint_satisfaction_diagnostics() {
                 werewolf_count,
                 cs.which_is_unsatisfied()
             );
+        }
+    }
+}
+
+#[test]
+fn role_assignment_local_calculate_output_matches_calc_shuffle_matrix_profiles() {
+    let profiles = [(5, 2), (6, 2), (7, 2), (7, 3), (8, 3)];
+
+    for (num_players, werewolf_count) in profiles {
+        let circuit = build_role_assignment_circuit(num_players, werewolf_count);
+
+        let role_outputs = circuit.calculate_output();
+        assert_eq!(role_outputs.len(), num_players);
+
+        let grouping_parameter = build_grouping_parameter(num_players, werewolf_count);
+        let shuffle_matrices = circuit
+            .private_input
+            .iter()
+            .map(|input| input.shuffle_matrices.clone())
+            .collect::<Vec<_>>();
+
+        for player_id in 0..num_players {
+            let (expected_role, _expected_role_val, _fellow_ids) =
+                calc_shuffle_matrix(&grouping_parameter, &shuffle_matrices, player_id).unwrap();
+            assert_eq!(
+                fr_to_u32(role_outputs[player_id]),
+                role_to_role_id(expected_role),
+                "unexpected role id for player {} in n{}-w{}",
+                player_id,
+                num_players,
+                werewolf_count
+            );
+        }
+    }
+}
+
+#[test]
+fn role_assignment_local_werewolf_mates_mask_matches_calc_shuffle_matrix_profiles() {
+    let profiles = [(5, 2), (6, 2), (7, 2), (7, 3), (8, 3)];
+
+    for (num_players, werewolf_count) in profiles {
+        let circuit = build_role_assignment_circuit(num_players, werewolf_count);
+        let outputs = circuit.calculate_output_with_werewolf_mates_mask();
+        assert_eq!(outputs.len(), num_players);
+
+        let grouping_parameter = build_grouping_parameter(num_players, werewolf_count);
+        let shuffle_matrices = circuit
+            .private_input
+            .iter()
+            .map(|input| input.shuffle_matrices.clone())
+            .collect::<Vec<_>>();
+
+        for player_id in 0..num_players {
+            let (role, _role_val, fellow_ids) =
+                calc_shuffle_matrix(&grouping_parameter, &shuffle_matrices, player_id).unwrap();
+
+            let expected_role_id = role_to_role_id(role);
+            assert_eq!(
+                fr_to_u32(outputs[player_id].role_share),
+                expected_role_id,
+                "unexpected role id for player {} in n{}-w{}",
+                player_id,
+                num_players,
+                werewolf_count
+            );
+
+            let expected_mask = if role == GroupingRole::Werewolf {
+                fellow_ids
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|&id| id != player_id)
+                    .fold(0u32, |acc, id| acc | (1u32 << id))
+            } else {
+                0u32
+            };
+
+            assert_eq!(
+                fr_to_u32(outputs[player_id].werewolf_mates_mask_share),
+                expected_mask,
+                "unexpected teammate mask for player {} in n{}-w{}",
+                player_id,
+                num_players,
+                werewolf_count
+            );
+        }
+    }
+}
+
+#[test]
+fn role_assignment_local_werewolf_players_see_other_werewolves_profiles() {
+    let profiles = [(5, 2), (6, 2), (7, 3), (8, 3)];
+
+    for (num_players, werewolf_count) in profiles {
+        let circuit = build_role_assignment_circuit(num_players, werewolf_count);
+        let outputs = circuit.calculate_output_with_werewolf_mates_mask();
+
+        let werewolf_ids = outputs
+            .iter()
+            .enumerate()
+            .filter_map(|(id, output)| {
+                if fr_to_u32(output.role_share) == role_to_role_id(GroupingRole::Werewolf) {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            werewolf_ids.len(),
+            werewolf_count,
+            "unexpected werewolf count in n{}-w{}",
+            num_players,
+            werewolf_count
+        );
+
+        for (player_id, output) in outputs.iter().enumerate() {
+            let mask = fr_to_u32(output.werewolf_mates_mask_share);
+            let mut actual_mates = decode_player_mask(mask, num_players);
+            actual_mates.sort_unstable();
+
+            if werewolf_ids.contains(&player_id) {
+                let mut expected_mates = werewolf_ids
+                    .iter()
+                    .copied()
+                    .filter(|&id| id != player_id)
+                    .collect::<Vec<_>>();
+                expected_mates.sort_unstable();
+
+                assert_eq!(
+                    actual_mates,
+                    expected_mates,
+                    "werewolf player {} has wrong mates in n{}-w{}",
+                    player_id,
+                    num_players,
+                    werewolf_count
+                );
+            } else {
+                assert!(
+                    actual_mates.is_empty(),
+                    "non-werewolf player {} should not receive werewolf mates in n{}-w{}",
+                    player_id,
+                    num_players,
+                    werewolf_count
+                );
+            }
         }
     }
 }

--- a/packages/nextjs/__tests__/e2e/circuits/setup.ts
+++ b/packages/nextjs/__tests__/e2e/circuits/setup.ts
@@ -115,22 +115,25 @@ function decodeWerewolfTeammateIdsForTest(
   maskValue: bigint,
   myRole: "Villager" | "Seer" | "Werewolf",
   myPlayerId: string,
+  playerOrderIds?: string[],
 ): string[] {
   if (myRole !== "Werewolf") {
     return [];
   }
 
-  const players = global.testPlayers ?? [];
+  const fallbackPlayers = global.testPlayers ?? [];
+  const orderedPlayerIds =
+    playerOrderIds && playerOrderIds.length > 0 ? playerOrderIds : fallbackPlayers.map(player => player.id);
   const normalizedMask = normalizeFieldElement(maskValue);
   const teammateIds: string[] = [];
-  for (let index = 0; index < players.length; index += 1) {
+  for (let index = 0; index < orderedPlayerIds.length; index += 1) {
     const bit = (normalizedMask >> BigInt(index)) & 1n;
     if (bit !== 1n) continue;
-    const teammateId = players[index]?.id;
+    const teammateId = orderedPlayerIds[index];
     if (!teammateId || teammateId === myPlayerId) continue;
     teammateIds.push(teammateId);
   }
-  return teammateIds;
+  return Array.from(new Set(teammateIds));
 }
 
 function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payload: any): void {
@@ -143,6 +146,10 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
   if (!encryptedRoleShare) {
     return;
   }
+  const playerOrderIds =
+    Array.isArray(payload?.result_data?.player_order) && payload.result_data.player_order.length > 0
+      ? payload.result_data.player_order.map((id: unknown) => String(id))
+      : undefined;
 
   const encrypted = encryptedRoleShare.encrypted as string | undefined;
   const nonce = encryptedRoleShare.nonce as string | undefined;
@@ -228,7 +235,12 @@ function reflectRoleAssignmentForPlayer(roomId: string, playerId: string, payloa
       combinedWerewolfMask = normalizeFieldElement(combinedWerewolfMask + share);
     }
     const roleName = decodeRoleName(combinedShare);
-    const werewolfTeammateIds = decodeWerewolfTeammateIdsForTest(combinedWerewolfMask, roleName, playerId);
+    const werewolfTeammateIds = decodeWerewolfTeammateIdsForTest(
+      combinedWerewolfMask,
+      roleName,
+      playerId,
+      playerOrderIds,
+    );
     const existingInfo = getPrivateGameInfo(roomId, playerId);
 
     if (!existingInfo) {

--- a/packages/nextjs/app/room/[id]/page.tsx
+++ b/packages/nextjs/app/room/[id]/page.tsx
@@ -255,8 +255,14 @@ export default function RoomPage({ params }: { params: { id: string } }) {
         return;
       }
 
-      const elapsedSec = Math.floor((Date.now() - phaseStartMs) / 1000);
-      setRemainingTime(Math.max(0, targetDuration - elapsedSec));
+      const nowMs = Date.now();
+      const pausedTotalSeconds = Math.max(0, Math.floor(gameInfo.phase_timer_paused_total_seconds ?? 0));
+      const pausedAtMs = gameInfo.phase_timer_paused_at ? new Date(gameInfo.phase_timer_paused_at).getTime() : NaN;
+      const activePausedSeconds = Number.isNaN(pausedAtMs) ? 0 : Math.max(0, Math.floor((nowMs - pausedAtMs) / 1000));
+
+      const rawElapsedSec = Math.floor((nowMs - phaseStartMs) / 1000);
+      const effectiveElapsedSec = Math.max(0, rawElapsedSec - pausedTotalSeconds - activePausedSeconds);
+      setRemainingTime(Math.max(0, targetDuration - effectiveElapsedSec));
     };
 
     updateRemainingTime();
@@ -355,7 +361,8 @@ export default function RoomPage({ params }: { params: { id: string } }) {
     playersForView.length > 0 &&
     playersForView.every(player => getPlayerReady(player as { isReady?: boolean; is_ready?: boolean }));
   const timerProgressPercent = Math.max(0, Math.min(100, (remainingTime / Math.max(phaseDuration, 1)) * 100));
-  const isTimeWarning = roomInfo?.status === "InProgress" && remainingTime <= 30;
+  const isPhaseTimerPaused = Boolean(gameInfo?.phase_timer_paused_at);
+  const isTimeWarning = roomInfo?.status === "InProgress" && !isPhaseTimerPaused && remainingTime <= 30;
   const isWebSocketConnected = websocketStatus === "connected";
   const websocketStatusLabel =
     websocketStatus === "connected"
@@ -459,7 +466,9 @@ export default function RoomPage({ params }: { params: { id: string } }) {
                 <div className="flex items-center gap-2 text-indigo-700">
                   <Clock size={18} />
                   <span>
-                    Time Remaining: {Math.floor(remainingTime / 60)}:{String(remainingTime % 60).padStart(2, "0")}
+                    {isPhaseTimerPaused
+                      ? "Computing proof..."
+                      : `Time Remaining: ${Math.floor(remainingTime / 60)}:${String(remainingTime % 60).padStart(2, "0")}`}
                   </span>
                 </div>
                 <div className="w-40">

--- a/packages/nextjs/hooks/useComputationResults.ts
+++ b/packages/nextjs/hooks/useComputationResults.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getFortuneTellerSecretKey, loadCryptoParams } from "~~/services/gameInputGenerator";
 import type { ChatMessage, PrivateGameInfo } from "~~/types/game";
 import { MPCEncryption } from "~~/utils/crypto/InputEncryption";
@@ -29,6 +29,7 @@ interface RoleAssignmentResult {
     role_share_encoding?: string;
     werewolf_mates_mask_share_encoding?: string;
   };
+  player_order?: string[];
   status: string;
 }
 
@@ -131,24 +132,30 @@ const decodeRoleName = (roleId: bigint): "Villager" | "Seer" | "Werewolf" => {
 
 const decodeWerewolfTeammateIds = (
   maskValue: bigint,
-  players: Array<{ id: string }> | undefined,
+  playerOrderIds: string[] | undefined,
   myPlayerId: string,
   myRole: "Villager" | "Seer" | "Werewolf",
 ): string[] => {
-  if (myRole !== "Werewolf" || !players || players.length === 0) {
+  if (myRole !== "Werewolf" || !playerOrderIds || playerOrderIds.length === 0) {
     return [];
   }
 
   const normalizedMask = normalizeFieldElement(maskValue);
   const teammateIds: string[] = [];
-  for (let index = 0; index < players.length; index += 1) {
+  for (let index = 0; index < playerOrderIds.length; index += 1) {
     const bit = (normalizedMask >> BigInt(index)) & 1n;
     if (bit !== 1n) continue;
-    const teammateId = players[index]?.id;
+    const teammateId = playerOrderIds[index];
     if (!teammateId || teammateId === myPlayerId) continue;
     teammateIds.push(teammateId);
   }
-  return teammateIds;
+  return Array.from(new Set(teammateIds));
+};
+
+const parsePlayerOrderIds = (raw: unknown): string[] | undefined => {
+  if (!Array.isArray(raw)) return undefined;
+  const ids = raw.map(id => String(id)).filter(id => id.length > 0);
+  return ids.length > 0 ? ids : undefined;
 };
 
 export const useComputationResults = (
@@ -169,6 +176,7 @@ export const useComputationResults = (
         requiredShares: number;
         roleSharesByNode: Map<number, bigint>;
         werewolfMaskSharesByNode: Map<number, bigint>;
+        playerOrderIds?: string[];
       }
     >
   >(new Map());
@@ -178,6 +186,101 @@ export const useComputationResults = (
     roleShareBuffersRef.current.clear();
     completedRoleBatchRef.current.clear();
   }, [playerId, roomId]);
+
+  const finalizeRoleAssignmentBatch = useCallback(
+    (
+      batchKey: string,
+      buffer: {
+        requiredShares: number;
+        roleSharesByNode: Map<number, bigint>;
+        werewolfMaskSharesByNode: Map<number, bigint>;
+        playerOrderIds?: string[];
+      },
+    ): boolean => {
+      if (completedRoleBatchRef.current.has(batchKey)) {
+        return true;
+      }
+      if (buffer.roleSharesByNode.size < buffer.requiredShares) {
+        return false;
+      }
+
+      const fallbackPlayerOrder = Array.isArray(gameInfo?.players)
+        ? gameInfo.players.map((player: any) => String(player.id))
+        : undefined;
+      const playerOrderIds = buffer.playerOrderIds ?? fallbackPlayerOrder;
+      if (!playerOrderIds || playerOrderIds.length === 0) {
+        return false;
+      }
+
+      let combinedRoleShare = 0n;
+      for (const share of buffer.roleSharesByNode.values()) {
+        combinedRoleShare = normalizeFieldElement(combinedRoleShare + share);
+      }
+
+      let combinedWerewolfMaskShare = 0n;
+      for (const share of buffer.werewolfMaskSharesByNode.values()) {
+        combinedWerewolfMaskShare = normalizeFieldElement(combinedWerewolfMaskShare + share);
+      }
+
+      const roleName = decodeRoleName(combinedRoleShare);
+      const werewolfTeammateIds = decodeWerewolfTeammateIds(
+        combinedWerewolfMaskShare,
+        playerOrderIds,
+        playerId,
+        roleName,
+      );
+
+      const existingInfo = getPrivateGameInfo(roomId, playerId);
+      if (!existingInfo) {
+        const initialInfo: PrivateGameInfo = {
+          playerId,
+          playerRole: null as any,
+          werewolfTeammateIds: [],
+          hasActed: false,
+        };
+        setPrivateGameInfo(roomId, initialInfo);
+      }
+
+      const updatedInfo = updatePrivateGameInfo(roomId, playerId, {
+        playerRole: roleName as "Villager" | "Werewolf" | "Seer",
+        werewolfTeammateIds,
+      });
+
+      if (!updatedInfo) {
+        console.error("Failed to update PrivateGameInfo even after initialization attempt");
+        return false;
+      }
+
+      completedRoleBatchRef.current.add(batchKey);
+      roleShareBuffersRef.current.delete(batchKey);
+
+      const werewolfTeammateNames = werewolfTeammateIds
+        .map(id => gameInfo?.players?.find((player: any) => String(player.id) === String(id))?.name || id)
+        .filter((name, index, self) => self.indexOf(name) === index);
+
+      addMessage({
+        id: Date.now().toString(),
+        sender: "System",
+        message:
+          roleName === "Werewolf" && werewolfTeammateNames.length > 0
+            ? `Your role has been assigned: ${roleName} (teammates: ${werewolfTeammateNames.join(", ")})`
+            : `Your role has been assigned: ${roleName}`,
+        timestamp: new Date().toISOString(),
+        type: "system",
+      });
+
+      window.dispatchEvent(new CustomEvent("roleAssignmentCompleted"));
+      return true;
+    },
+    [addMessage, gameInfo?.players, playerId, roomId],
+  );
+
+  useEffect(() => {
+    if (!playerId || !roomId) return;
+    for (const [batchKey, buffer] of roleShareBuffersRef.current.entries()) {
+      finalizeRoleAssignmentBatch(batchKey, buffer);
+    }
+  }, [finalizeRoleAssignmentBatch, playerId, roomId]);
 
   useEffect(() => {
     if (!roomId || !playerId) return;
@@ -452,6 +555,8 @@ export const useComputationResults = (
                 break;
               }
 
+              const playerOrderIds = parsePlayerOrderIds(result.resultData?.player_order);
+
               const decryptedBinary = cryptoManager.decryptBinary(encrypted, nonce, senderPublicKey);
               const decoder = new TextDecoder("utf-8");
               const decryptedString = decoder.decode(decryptedBinary);
@@ -498,77 +603,22 @@ export const useComputationResults = (
                 requiredShares,
                 roleSharesByNode: new Map<number, bigint>(),
                 werewolfMaskSharesByNode: new Map<number, bigint>(),
+                playerOrderIds,
               };
               existingBuffer.requiredShares = Math.max(existingBuffer.requiredShares, requiredShares);
+              if (playerOrderIds && playerOrderIds.length > 0) {
+                existingBuffer.playerOrderIds = playerOrderIds;
+              }
               if (existingBuffer.roleSharesByNode.has(nodeId)) {
+                roleShareBuffersRef.current.set(batchKey, existingBuffer);
+                finalizeRoleAssignmentBatch(batchKey, existingBuffer);
                 break;
               }
               existingBuffer.roleSharesByNode.set(nodeId, roleShare);
               existingBuffer.werewolfMaskSharesByNode.set(nodeId, werewolfMatesMaskShare);
               roleShareBuffersRef.current.set(batchKey, existingBuffer);
 
-              if (existingBuffer.roleSharesByNode.size < existingBuffer.requiredShares) {
-                break;
-              }
-
-              let combinedRoleShare = 0n;
-              for (const share of existingBuffer.roleSharesByNode.values()) {
-                combinedRoleShare = normalizeFieldElement(combinedRoleShare + share);
-              }
-
-              let combinedWerewolfMaskShare = 0n;
-              for (const share of existingBuffer.werewolfMaskSharesByNode.values()) {
-                combinedWerewolfMaskShare = normalizeFieldElement(combinedWerewolfMaskShare + share);
-              }
-
-              const roleName = decodeRoleName(combinedRoleShare);
-              const werewolfTeammateIds = decodeWerewolfTeammateIds(
-                combinedWerewolfMaskShare,
-                gameInfo?.players,
-                playerId,
-                roleName,
-              );
-              let existingInfo = getPrivateGameInfo(roomId, playerId);
-
-              if (!existingInfo) {
-                const initialInfo: PrivateGameInfo = {
-                  playerId,
-                  playerRole: null as any,
-                  werewolfTeammateIds: [],
-                  hasActed: false,
-                };
-                setPrivateGameInfo(roomId, initialInfo);
-                existingInfo = initialInfo;
-              }
-
-              const updatedInfo = updatePrivateGameInfo(roomId, playerId, {
-                playerRole: roleName as "Villager" | "Werewolf" | "Seer",
-                werewolfTeammateIds,
-              });
-
-              if (!updatedInfo) {
-                console.error("Failed to update PrivateGameInfo even after initialization attempt");
-              }
-
-              completedRoleBatchRef.current.add(batchKey);
-              roleShareBuffersRef.current.delete(batchKey);
-
-              const werewolfTeammateNames = werewolfTeammateIds
-                .map(id => gameInfo?.players?.find((player: any) => String(player.id) === String(id))?.name || id)
-                .filter((name, index, self) => self.indexOf(name) === index);
-
-              addMessage({
-                id: Date.now().toString(),
-                sender: "System",
-                message:
-                  roleName === "Werewolf" && werewolfTeammateNames.length > 0
-                    ? `Your role has been assigned: ${roleName} (teammates: ${werewolfTeammateNames.join(", ")})`
-                    : `Your role has been assigned: ${roleName}`,
-                timestamp: new Date().toISOString(),
-                type: "system",
-              });
-
-              window.dispatchEvent(new CustomEvent("roleAssignmentCompleted"));
+              finalizeRoleAssignmentBatch(batchKey, existingBuffer);
             } catch (error) {
               console.error("Role decryption error:", error);
               addMessage({
@@ -626,7 +676,7 @@ export const useComputationResults = (
     return () => {
       window.removeEventListener("computationResultNotification", handleComputationResult);
     };
-  }, [playerId, addMessage, roomId, gameInfo]);
+  }, [playerId, addMessage, roomId, gameInfo, finalizeRoleAssignmentBatch]);
 
   return {
     divinationResult,

--- a/packages/nextjs/hooks/useGameActions.ts
+++ b/packages/nextjs/hooks/useGameActions.ts
@@ -1,10 +1,8 @@
 import { useState } from "react";
-import type { ChatMessage, GameInfo, PrivateGameInfo } from "~~/types/game";
+import type { ChatMessage, GameInfo } from "~~/types/game";
 import {
   clearPrivateGameInfo,
-  getPrivateGameInfo,
   initializePrivateGameInfo,
-  setPrivateGameInfo as saveToStorage,
   updateHasActed,
   updatePrivateGameInfo,
 } from "~~/utils/privateGameInfoUtils";
@@ -30,17 +28,12 @@ export const useGameActions = (
         throw new Error("Failed to start game");
       }
 
-      // Initialize PrivateGameInfo with null role (undetermined) when game starts
+      // Always reset PrivateGameInfo at game start to avoid stale role state
+      // carrying over between sessions/restarts.
       if (userId) {
         try {
-          // すでにRoleが割り当てられている場合は上書きしない
-          const existingInfo = getPrivateGameInfo(roomId, userId);
-          if (existingInfo && existingInfo.playerRole !== null) {
-            console.log("PrivateGameInfo already has role assigned, skipping initialization:", existingInfo);
-          } else {
-            initializePrivateGameInfo(roomId, userId);
-            console.log("PrivateGameInfo initialized with null role in session storage");
-          }
+          initializePrivateGameInfo(roomId, userId);
+          console.log("PrivateGameInfo reset with null role in session storage");
         } catch (storageError) {
           console.error("PrivateGameInfo initialization error:", storageError);
         }

--- a/packages/nextjs/hooks/useGameInfo.ts
+++ b/packages/nextjs/hooks/useGameInfo.ts
@@ -67,32 +67,20 @@ export const useGameInfo = (
         const currentPlayer = data.players.find((player: any) => player.id === userId);
 
         if (currentPlayer) {
-          // 既存のPrivateGameInfoを確認
-          const existingPrivateInfo = getPrivateGameInfo(roomId, userId);
+          // PrivateGameInfoを常に初期化（roleはMPC計算結果から後で設定）
+          const newPrivateInfo: PrivateGameInfo = {
+            playerId: userId,
+            playerRole: null as any, // Roleはまだ未決定
+            werewolfTeammateIds: [],
+            hasActed: false,
+          };
 
-          // すでにRoleが割り当てられている場合は上書きしない
-          if (existingPrivateInfo && existingPrivateInfo.playerRole !== null) {
-            console.log(
-              "PrivateGameInfo already exists with role assigned, skipping initialization:",
-              existingPrivateInfo,
-            );
-            setPrivateGameInfoState(existingPrivateInfo);
-          } else {
-            // PrivateGameInfoを初期化（roleはMPC計算結果から後で設定）
-            const newPrivateInfo: PrivateGameInfo = {
-              playerId: userId,
-              playerRole: null as any, // Roleはまだ未決定
-              werewolfTeammateIds: [],
-              hasActed: false,
-            };
+          // セッションストレージに保存
+          setPrivateGameInfo(roomId, newPrivateInfo);
+          console.log("PrivateGameInfo reset for newly started game:", newPrivateInfo);
 
-            // セッションストレージに保存
-            setPrivateGameInfo(roomId, newPrivateInfo);
-            console.log("PrivateGameInfo initialized for player (role not yet assigned):", newPrivateInfo);
-
-            // ステート更新
-            setPrivateGameInfoState(newPrivateInfo);
-          }
+          // ステート更新
+          setPrivateGameInfoState(newPrivateInfo);
         }
       }
       // 通常の更新処理

--- a/packages/nextjs/types/game.ts
+++ b/packages/nextjs/types/game.ts
@@ -33,6 +33,8 @@ export interface GameInfo {
   phase: "Waiting" | "Night" | "DivinationProcessing" | "Discussion" | "Voting" | "Result" | "Finished";
   day_count?: number;
   phase_started_at?: string;
+  phase_timer_paused_at?: string | null;
+  phase_timer_paused_total_seconds?: number;
   players: Player[];
   playerRole: Role;
   hasActed: boolean;

--- a/packages/server/src/app.rs
+++ b/packages/server/src/app.rs
@@ -4,15 +4,13 @@ use axum::Router;
 use chrono::Duration;
 use tokio::time::{interval, Duration as TokioDuration};
 
-fn is_debug_mode_enabled() -> bool {
-    let debug_mode = std::env::var("DEBUG_MODE")
+fn is_auto_phase_advance_enabled() -> bool {
+    // Backward-compatible override:
+    // - DEBUG_AUTO_ADVANCE_PHASES=true/false explicitly controls auto progression.
+    // - If unset, auto progression is enabled by default even in debug mode.
+    std::env::var("DEBUG_AUTO_ADVANCE_PHASES")
         .map(|v| v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    let debug_enabled = std::env::var("DEBUG_ENABLED")
-        .map(|v| v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-
-    debug_mode || debug_enabled
+        .unwrap_or(true)
 }
 
 pub fn create_app() -> Router {
@@ -21,7 +19,7 @@ pub fn create_app() -> Router {
 
 pub fn create_app_with_state(state: AppState) -> Router {
     let auto_phase_state = state.clone();
-    if !is_debug_mode_enabled() {
+    if is_auto_phase_advance_enabled() {
         tokio::spawn(async move {
             let mut ticker = interval(TokioDuration::from_secs(1));
             loop {
@@ -30,6 +28,8 @@ pub fn create_app_with_state(state: AppState) -> Router {
                     .await;
             }
         });
+    } else {
+        tracing::info!("Auto phase advance is disabled by DEBUG_AUTO_ADVANCE_PHASES");
     }
 
     let cleanup_state = state.clone();

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -1189,6 +1189,11 @@ impl Game {
                     }
                     CircuitEncryptedInputIdentifier::RoleAssignment(_items) => {
                         println!("RoleAssignment process is starting...");
+                        let player_order: Vec<String> = self
+                            .players
+                            .iter()
+                            .map(|player| player.id.clone())
+                            .collect();
 
                         let Some(encrypted_shares) = output.shares else {
                             println!("RoleAssignment failed: no encrypted shares in proof output");
@@ -1225,6 +1230,7 @@ impl Game {
                             serde_json::json!({
                                 "encrypted_share_count": encrypted_shares.len(),
                                 "required_shares_by_player": required_shares_by_player.clone(),
+                                "player_order": player_order.clone(),
                                 "schema_version": "role_assignment_share_v2",
                                 "share_encoding": "bn254_fr_decimal_string",
                                 "role_share_encoding": "bn254_fr_decimal_string",
@@ -1273,6 +1279,7 @@ impl Game {
                                     "role_share_encoding": "bn254_fr_decimal_string",
                                     "werewolf_mates_mask_share_encoding": "player_index_bitmask_lsb0"
                                 },
+                                "player_order": player_order.clone(),
                                 "status": "ready"
                             });
 

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -41,6 +41,10 @@ pub struct Game {
     pub computation_results: ComputationResults,
     pub started_at: Option<DateTime<Utc>>,
     pub phase_started_at: DateTime<Utc>,
+    #[serde(default)]
+    pub phase_timer_paused_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub phase_timer_paused_total_seconds: u64,
     pub grouping_parameter: GroupingParameter,
 }
 
@@ -378,6 +382,8 @@ impl Game {
             computation_results: ComputationResults::default(),
             started_at: Some(Utc::now()),
             phase_started_at: Utc::now(),
+            phase_timer_paused_at: None,
+            phase_timer_paused_total_seconds: 0,
             grouping_parameter,
         }
     }
@@ -433,6 +439,50 @@ impl Game {
             || !self.active_batches.is_empty()
     }
 
+    pub fn pause_phase_timer(&mut self) {
+        self.pause_phase_timer_at(Utc::now());
+    }
+
+    pub fn pause_phase_timer_at(&mut self, now: DateTime<Utc>) {
+        if self.phase_timer_paused_at.is_none() {
+            self.phase_timer_paused_at = Some(now);
+        }
+    }
+
+    pub fn resume_phase_timer(&mut self) {
+        self.resume_phase_timer_at(Utc::now());
+    }
+
+    pub fn resume_phase_timer_at(&mut self, now: DateTime<Utc>) {
+        if let Some(paused_at) = self.phase_timer_paused_at.take() {
+            let paused_seconds = now.signed_duration_since(paused_at).num_seconds().max(0) as u64;
+            self.phase_timer_paused_total_seconds = self
+                .phase_timer_paused_total_seconds
+                .saturating_add(paused_seconds);
+        }
+    }
+
+    pub fn effective_phase_elapsed_seconds(&self) -> i64 {
+        self.effective_phase_elapsed_seconds_at(Utc::now())
+    }
+
+    pub fn effective_phase_elapsed_seconds_at(&self, now: DateTime<Utc>) -> i64 {
+        let total_elapsed_seconds = now
+            .signed_duration_since(self.phase_started_at)
+            .num_seconds()
+            .max(0);
+        let mut paused_seconds = if self.phase_timer_paused_total_seconds > i64::MAX as u64 {
+            i64::MAX
+        } else {
+            self.phase_timer_paused_total_seconds as i64
+        };
+        if let Some(paused_at) = self.phase_timer_paused_at {
+            let active_pause_seconds = now.signed_duration_since(paused_at).num_seconds().max(0);
+            paused_seconds = paused_seconds.saturating_add(active_pause_seconds);
+        }
+        total_elapsed_seconds.saturating_sub(paused_seconds).max(0)
+    }
+
     // DivinationProcessing フェーズから Discussion フェーズへの遷移を管理
     pub async fn complete_divination_processing(&mut self, app_state: &crate::state::AppState) {
         if self.phase == GamePhase::DivinationProcessing {
@@ -467,6 +517,8 @@ impl Game {
 
         self.phase = new_phase.clone();
         self.phase_started_at = Utc::now();
+        self.phase_timer_paused_at = None;
+        self.phase_timer_paused_total_seconds = 0;
         self.add_phase_change_message(old_phase, new_phase);
     }
     pub fn save_role_assignment_result(
@@ -715,11 +767,17 @@ impl Game {
 
     pub async fn process_current_batch(&mut self, app_state: &crate::state::AppState) {
         if self.batch_request.requests.is_empty() {
+            if !self.has_pending_or_processing_batches() {
+                self.resume_phase_timer();
+            }
             return;
         }
 
         self.process_batch(app_state).await;
         self.batch_request = BatchRequest::new(0);
+        if !self.has_pending_or_processing_batches() {
+            self.resume_phase_timer();
+        }
     }
 
     async fn process_batch(&mut self, app_state: &crate::state::AppState) {
@@ -1335,6 +1393,108 @@ impl std::fmt::Display for Game {
             "Game {{ room_id: {}, name: {}, players: {:?}, phase: {:?}, result: {:?} }}",
             self.room_id, self.name, self.players, self.phase, self.result
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use std::collections::BTreeMap;
+
+    fn make_grouping_parameter() -> GroupingParameter {
+        let mut map = BTreeMap::new();
+        map.insert(Role::FortuneTeller, (1, false));
+        map.insert(Role::Werewolf, (1, false));
+        map.insert(Role::Villager, (2, false));
+        GroupingParameter::new(map)
+    }
+
+    fn make_test_game() -> Game {
+        let players = vec![
+            Player {
+                id: "p1".to_string(),
+                name: "p1".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+            Player {
+                id: "p2".to_string(),
+                name: "p2".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+            Player {
+                id: "p3".to_string(),
+                name: "p3".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+            Player {
+                id: "p4".to_string(),
+                name: "p4".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+        ];
+        Game::new(
+            "room-timer-test".to_string(),
+            players,
+            4,
+            make_grouping_parameter(),
+        )
+    }
+
+    #[test]
+    fn pause_resume_accumulates_paused_duration() {
+        let mut game = make_test_game();
+        let started_at = Utc::now();
+        game.phase_started_at = started_at;
+
+        let pause_at = started_at + Duration::seconds(10);
+        let resume_at = started_at + Duration::seconds(25);
+        let check_at = started_at + Duration::seconds(35);
+
+        game.pause_phase_timer_at(pause_at);
+        assert_eq!(game.effective_phase_elapsed_seconds_at(resume_at), 10);
+
+        game.resume_phase_timer_at(resume_at);
+
+        assert_eq!(game.phase_timer_paused_at, None);
+        assert_eq!(game.phase_timer_paused_total_seconds, 15);
+        assert_eq!(game.effective_phase_elapsed_seconds_at(check_at), 20);
+    }
+
+    #[test]
+    fn multiple_pause_resume_cycles_accumulate() {
+        let mut game = make_test_game();
+        let started_at = Utc::now();
+        game.phase_started_at = started_at;
+
+        game.pause_phase_timer_at(started_at + Duration::seconds(5));
+        game.resume_phase_timer_at(started_at + Duration::seconds(9));
+        game.pause_phase_timer_at(started_at + Duration::seconds(12));
+        game.resume_phase_timer_at(started_at + Duration::seconds(15));
+
+        assert_eq!(game.phase_timer_paused_total_seconds, 7);
+        assert_eq!(
+            game.effective_phase_elapsed_seconds_at(started_at + Duration::seconds(25)),
+            18
+        );
+    }
+
+    #[test]
+    fn change_phase_resets_timer_pause_state() {
+        let mut game = make_test_game();
+        game.phase = GamePhase::Night;
+        game.phase_timer_paused_at = Some(Utc::now());
+        game.phase_timer_paused_total_seconds = 42;
+
+        game.change_phase(GamePhase::Discussion);
+
+        assert_eq!(game.phase, GamePhase::Discussion);
+        assert_eq!(game.phase_timer_paused_at, None);
+        assert_eq!(game.phase_timer_paused_total_seconds, 0);
     }
 }
 

--- a/packages/server/src/models/game.rs
+++ b/packages/server/src/models/game.rs
@@ -723,7 +723,9 @@ impl Game {
             let insert_pos = batch
                 .requests
                 .iter()
-                .position(|existing| player_index_of(existing.get_user_id()) > new_request_player_index)
+                .position(|existing| {
+                    player_index_of(existing.get_user_id()) > new_request_player_index
+                })
                 .unwrap_or(batch.requests.len());
             batch.requests.insert(insert_pos, request);
         }
@@ -1202,18 +1204,15 @@ impl Game {
                             println!("RoleAssignment failed: encrypted share list is empty");
                             self.batch_request.status = BatchStatus::Failed;
                             self.chat_log.add_system_message(
-                                "Role assignment failed: encrypted shares were empty."
-                                    .to_string(),
+                                "Role assignment failed: encrypted shares were empty.".to_string(),
                             );
                             return;
                         }
 
                         println!("Received {} encrypted role shares", encrypted_shares.len());
 
-                        let mut required_shares_by_player = std::collections::HashMap::<
-                            String,
-                            usize,
-                        >::new();
+                        let mut required_shares_by_player =
+                            std::collections::HashMap::<String, usize>::new();
                         for share in &encrypted_shares {
                             *required_shares_by_player
                                 .entry(share.user_id.clone())
@@ -1295,8 +1294,7 @@ impl Game {
                         }
 
                         self.chat_log.add_system_message(
-                            "Roles have been assigned. Check your private information."
-                                .to_string(),
+                            "Roles have been assigned. Check your private information.".to_string(),
                         );
                     }
                     CircuitEncryptedInputIdentifier::KeyPublicize(_items) => {

--- a/packages/server/src/routes/game.rs
+++ b/packages/server/src/routes/game.rs
@@ -88,13 +88,10 @@ pub async fn get_game_state(
     Path(room_id): Path<String>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    // match game_service::get_game_state(state, room_id).await {
-    //     Ok(game) => (StatusCode::OK, Json(game)),
-    //     Err(message) => (StatusCode::NOT_FOUND, Json(message)),
-    // }
-    let game = game_service::get_game_state(state, room_id).await.unwrap();
-    (StatusCode::OK, Json(game))
-    // Err(message) => (StatusCode::NOT_FOUND, Json(message)),
+    match game_service::get_game_state(state, room_id).await {
+        Ok(game) => (StatusCode::OK, Json(game)).into_response(),
+        Err(message) => (StatusCode::NOT_FOUND, Json(message)).into_response(),
+    }
 }
 
 async fn end_game_handler(
@@ -307,6 +304,8 @@ async fn reset_game_handler(
         let mut reset_game = game.clone();
         reset_game.phase = GamePhase::Waiting;
         reset_game.phase_started_at = chrono::Utc::now();
+        reset_game.phase_timer_paused_at = None;
+        reset_game.phase_timer_paused_total_seconds = 0;
         reset_game.chat_log.messages.clear();
         // reset_game.has_acted.clear();
 
@@ -382,6 +381,7 @@ async fn reset_batch_request_handler(
         // バッチリクエストを新しいものに置き換え
         game.batch_request = BatchRequest::new(0);
         game.active_batches.clear();
+        game.resume_phase_timer();
 
         // システムメッセージを追加
         game.chat_log

--- a/packages/server/src/services/game_service.rs
+++ b/packages/server/src/services/game_service.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use ark_bn254::Fr;
 use ark_crypto_primitives::{encryption::AsymmetricEncryptionScheme, CommitmentScheme};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use mpc_algebra_wasm::{GroupingParameter, Role as GroupingRole};
 use rand::seq::SliceRandom;
 use std::collections::BTreeMap;
@@ -192,6 +192,22 @@ fn phase_duration_seconds(time_config: &TimeConfig, phase: &GamePhase) -> Option
     }
 }
 
+fn is_phase_due(game: &Game, time_config: &TimeConfig, now: DateTime<Utc>) -> bool {
+    if game.phase == GamePhase::Waiting || game.phase == GamePhase::Finished {
+        return false;
+    }
+
+    if game.has_pending_or_processing_batches() {
+        return false;
+    }
+
+    let Some(duration_secs) = phase_duration_seconds(time_config, &game.phase) else {
+        return false;
+    };
+
+    game.effective_phase_elapsed_seconds_at(now) >= duration_secs as i64
+}
+
 pub async fn auto_advance_due_phases(state: AppState) {
     let now = Utc::now();
     let due_room_ids = {
@@ -207,21 +223,7 @@ pub async fn auto_advance_due_phases(state: AppState) {
                     return None;
                 }
 
-                if game.phase == GamePhase::Waiting || game.phase == GamePhase::Finished {
-                    return None;
-                }
-
-                if game.has_pending_or_processing_batches() {
-                    return None;
-                }
-
-                let duration_secs =
-                    phase_duration_seconds(&room.room_config.time_config, &game.phase)?;
-                let elapsed_secs = now
-                    .signed_duration_since(game.phase_started_at)
-                    .num_seconds();
-
-                if elapsed_secs >= duration_secs as i64 {
+                if is_phase_due(game, &room.room_config.time_config, now) {
                     Some(room_id.clone())
                 } else {
                     None
@@ -534,4 +536,94 @@ pub fn initialize_crypto_parameters(game: &mut Game) {
     });
 
     tracing::info!("Initialized crypto parameters for game {}", game.room_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{game::BatchRequest, player::Player, room::RoleConfig};
+    use chrono::Duration;
+
+    fn make_players() -> Vec<Player> {
+        vec![
+            Player {
+                id: "p1".to_string(),
+                name: "p1".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+            Player {
+                id: "p2".to_string(),
+                name: "p2".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+            Player {
+                id: "p3".to_string(),
+                name: "p3".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+            Player {
+                id: "p4".to_string(),
+                name: "p4".to_string(),
+                is_dead: false,
+                is_ready: true,
+            },
+        ]
+    }
+
+    fn make_game() -> Game {
+        let role_config = RoleConfig {
+            seer: 1,
+            werewolf: 1,
+            villager: 2,
+        };
+        Game::new(
+            "room-auto-advance-test".to_string(),
+            make_players(),
+            4,
+            grouping_parameter_from_role_config(&role_config),
+        )
+    }
+
+    #[test]
+    fn phase_is_not_due_immediately_after_long_paused_proof_time() {
+        let mut game = make_game();
+        let now = Utc::now();
+        let time_config = TimeConfig {
+            day_phase: 300,
+            night_phase: 120,
+            voting_phase: 90,
+        };
+
+        game.phase = GamePhase::Night;
+        game.phase_started_at = now - Duration::seconds(260);
+        game.phase_timer_paused_total_seconds = 250;
+        game.phase_timer_paused_at = None;
+        game.batch_request = BatchRequest::new(0);
+        game.active_batches.clear();
+
+        assert!(!is_phase_due(&game, &time_config, now));
+    }
+
+    #[test]
+    fn phase_is_not_due_while_batches_are_pending() {
+        let mut game = make_game();
+        let now = Utc::now();
+        let time_config = TimeConfig {
+            day_phase: 300,
+            night_phase: 120,
+            voting_phase: 90,
+        };
+
+        game.phase = GamePhase::Night;
+        game.phase_started_at = now - Duration::seconds(500);
+        game.phase_timer_paused_total_seconds = 0;
+        game.phase_timer_paused_at = None;
+        game.batch_request = BatchRequest::new(1);
+        game.batch_request.status = crate::models::game::BatchStatus::Processing;
+
+        assert!(!is_phase_due(&game, &time_config, now));
+    }
 }

--- a/packages/server/src/services/zk_proof.rs
+++ b/packages/server/src/services/zk_proof.rs
@@ -108,7 +108,9 @@ pub async fn check_proof_status(proof_id: &str) -> Result<(bool, Option<ProofOut
                     failed_details.push(format!(
                         "{}:{}",
                         node_url,
-                        status.message.unwrap_or_else(|| "no error message".to_string())
+                        status
+                            .message
+                            .unwrap_or_else(|| "no error message".to_string())
                     ));
                 }
                 _ => continue,
@@ -203,16 +205,18 @@ pub async fn check_status_with_retry(
 }
 
 pub async fn execute_batch_request(batch_request: &BatchRequest) -> BatchExecutionResult {
-    // Keep canonical order from Game::add_request_to_batch.
-    // Re-sorting here can break index-based outputs (e.g. role shares / werewolf mate mask).
-    let ordered_requests = batch_request.requests.clone();
+    let mut sorted_requests = batch_request.requests.clone();
+    // Sort by player index (numeric user_id). Non-numeric values are pushed to the end
+    // and preserve relative order because sort_by_key is stable.
+    sorted_requests
+        .sort_by_key(|request| request.get_user_id().parse::<usize>().unwrap_or(usize::MAX));
 
-    let identifier = try_convert_to_identifier(ordered_requests.clone())?;
+    let identifier = try_convert_to_identifier(sorted_requests.clone())?;
 
     let output_type = match &identifier {
         CircuitEncryptedInputIdentifier::RoleAssignment(_) => {
             let mut player_pubkeys = Vec::new();
-            for request in &ordered_requests {
+            for request in &sorted_requests {
                 if let Some(pubkey) = request.get_public_key() {
                     player_pubkeys.push(zk_mpc_node::UserPublicKey {
                         user_id: request.get_user_id().to_string(),

--- a/packages/server/src/services/zk_proof.rs
+++ b/packages/server/src/services/zk_proof.rs
@@ -350,6 +350,7 @@ pub async fn batch_proof_handling(
             .map_err(|error| match error {
                 BatchEnqueueError::Conflict(message) => ProofHandlingError::Conflict(message),
             })?;
+        game.pause_phase_timer();
         let job = if enqueue_result.should_process {
             Some(ProofJob {
                 room_id: room_id.to_string(),


### PR DESCRIPTION
# Fix Game Time Progression And Proof-Driven Flow

## 概要(日本語)
proof送信中にフェーズ時間が消費されてしまう問題を解消し、proof完了後に残り時間から再開するようにしました。あわせて、proof処理まわりの順序整合性とクライアント側の状態初期化を改善しています。

## Summary (English)
This PR fixes phase time progression during proof processing by pausing the timer while proofs are pending and resuming from the remaining time after completion. It also improves proof-order consistency and client-side state reset behavior.

## Changes
- Server: Added phase timer pause/resume state to `Game` (`phase_timer_paused_at`, `phase_timer_paused_total_seconds`) and reset these values on phase change.
- Server: Added effective elapsed-time calculation and switched auto phase advancement to use effective elapsed time (excluding paused duration).
- Server: Pause timer when proof requests are accepted, and resume when no pending/processing batch remains.
- Server: Updated batch/proof flow around `game_service` and `zk_proof` to align with paused timer behavior.
- Server/Circuit: Added player-order tracking and related handling for role-assignment/share processing to keep deterministic ordering.
- Frontend: Updated `GameInfo` type and room page countdown logic to support paused timer fields and paused-state UI behavior.
- Frontend: Reset `PrivateGameInfo` role state on game start to avoid stale role reuse across runs.
- Frontend: Adjusted game info/result handling hooks for the updated timer/proof state behavior.
- Tests: Updated/extended local circuit test and E2E setup for the new flow.

## Related
- PR: #208
- E2E: `n5-w2-focus` passed (`__tests__/e2e/circuits/integration.full.test.ts`, 2026-03-18)