### PR TITLE
feat: add custom domain app.zk-werewolf.yoii.jp with HTTPS

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -36,7 +36,35 @@ provider "aws" {
 }
 
 locals {
-  name = "zk-werewolf-dev"
+  name   = "zk-werewolf-dev"
+  domain = "zk-werewolf.yoii.jp"
+}
+
+# =============================================================================
+# DNS (remote state from dns-yoii-jp)
+# =============================================================================
+
+data "terraform_remote_state" "dns" {
+  backend = "remote"
+
+  config = {
+    organization = "Yoii"
+    workspaces = {
+      name = "yoii-jp"
+    }
+  }
+}
+
+resource "aws_route53_record" "app" {
+  zone_id = data.terraform_remote_state.dns.outputs.zk_werewolf_hosted_zone.zone_id
+  name    = "app.${local.domain}"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.alb_dns_name
+    zone_id                = module.alb.alb_zone_id
+    evaluate_target_health = true
+  }
 }
 
 # Validate that secrets file exists
@@ -139,7 +167,7 @@ module "alb" {
   subnet_ids        = module.vpc.public_subnets
   security_group_id = module.security_groups.alb_security_group_id
 
-  certificate_arn            = "" # Add ACM certificate ARN for HTTPS
+  certificate_arn            = data.terraform_remote_state.dns.outputs.zk_werewolf_acm_arn
   enable_deletion_protection = false
 }
 
@@ -293,11 +321,11 @@ module "frontend_service" {
     },
     {
       name  = "NEXT_PUBLIC_API_URL"
-      value = "http://${module.alb.alb_dns_name}/api"
+      value = "https://app.${local.domain}/api"
     },
     {
       name  = "NEXT_PUBLIC_WS_URL"
-      value = "ws://${module.alb.alb_dns_name}/api"
+      value = "wss://app.${local.domain}/api"
     }
   ]
 

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -127,18 +127,18 @@ output "frontend_task_definition_arn" {
 
 # Application URLs
 output "application_url" {
-  description = "Application URL (ALB endpoint)"
-  value       = "http://${module.alb.alb_dns_name}"
+  description = "Application URL"
+  value       = "https://app.${local.domain}"
 }
 
 output "api_url" {
   description = "API URL"
-  value       = "http://${module.alb.alb_dns_name}/api"
+  value       = "https://app.${local.domain}/api"
 }
 
 output "ws_url" {
   description = "WebSocket URL"
-  value       = "ws://${module.alb.alb_dns_name}/ws"
+  value       = "wss://app.${local.domain}/ws"
 }
 
 # Frontend build-time public keys (from SOPS secrets)


### PR DESCRIPTION
## Summary
- Add Route53 A record `app.zk-werewolf.yoii.jp` → ALB (alias)
- Configure ACM wildcard certificate (`*.zk-werewolf.yoii.jp`) on ALB for HTTPS
- Reference dns-yoii-jp workspace via `terraform_remote_state` for zone ID and ACM ARN
- Update frontend env vars and outputs to `https://app.zk-werewolf.yoii.jp`

## Test plan
- [ ] `terraform plan` passes in HCP Terraform
- [ ] Apply and verify `app.zk-werewolf.yoii.jp` resolves to ALB
- [ ] Verify HTTPS works with valid certificate
- [ ] Verify HTTP → HTTPS redirect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)