### PR TITLE
fix: use terraform outputs for frontend Docker build URLs

### DIFF
--- a/scripts/deploy-to-ecr.sh
+++ b/scripts/deploy-to-ecr.sh
@@ -90,8 +90,9 @@ BACKEND_REPO=$(get_terraform_output "backend_repository_url")
 FRONTEND_REPO=$(get_terraform_output "frontend_repository_url")
 MPC_NODE_REPO=$(get_terraform_output "mpc_node_repository_url")
 
-# Get ALB DNS name for frontend build args
-ALB_DNS=$(get_terraform_output "alb_dns_name")
+# Get application URLs for frontend build args
+API_URL=$(get_terraform_output "api_url")
+WS_URL=$(get_terraform_output "ws_url")
 MPC_NODE0_PUBLIC_KEY=$(get_terraform_output "mpc_node_0_public_key")
 MPC_NODE1_PUBLIC_KEY=$(get_terraform_output "mpc_node_1_public_key")
 MPC_NODE2_PUBLIC_KEY=$(get_terraform_output "mpc_node_2_public_key")
@@ -219,8 +220,8 @@ build_frontend_image() {
     fi
 
     build_and_push "frontend" "packages/nextjs/Dockerfile" "${FRONTEND_REPO}" "latest" \
-        "NEXT_PUBLIC_API_URL=http://${ALB_DNS}/api" \
-        "NEXT_PUBLIC_WS_URL=ws://${ALB_DNS}/api" \
+        "NEXT_PUBLIC_API_URL=${API_URL}" \
+        "NEXT_PUBLIC_WS_URL=${WS_URL}" \
         "NEXT_PUBLIC_MPC_NODE0_PUBLIC_KEY=${MPC_NODE0_PUBLIC_KEY}" \
         "NEXT_PUBLIC_MPC_NODE1_PUBLIC_KEY=${MPC_NODE1_PUBLIC_KEY}" \
         "NEXT_PUBLIC_MPC_NODE2_PUBLIC_KEY=${MPC_NODE2_PUBLIC_KEY}"

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -138,7 +138,7 @@ output "api_url" {
 
 output "ws_url" {
   description = "WebSocket URL"
-  value       = "wss://app.${local.domain}/ws"
+  value       = "wss://app.${local.domain}/api"
 }
 
 # Frontend build-time public keys (from SOPS secrets)


### PR DESCRIPTION
## Summary
- `deploy-to-ecr.sh` was hardcoding `http://{ALB_DNS}/api` for `NEXT_PUBLIC_API_URL`/`NEXT_PUBLIC_WS_URL` build args, ignoring the custom domain set in #214
- Now uses `api_url`/`ws_url` terraform outputs directly, so URL is defined in one place
- Fix `ws_url` output path from `/ws` to `/api` to match actual frontend WebSocket usage

## Test plan
- [ ] `terraform plan` shows ws_url output change
- [ ] Redeploy frontend and verify Request URL is `https://app.zk-werewolf.yoii.jp/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)