### PR TITLE
fix: remove unnecessary mainnet RPC and invalid Alchemy API fallback

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useInitializeNativeCurrencyPrice.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useInitializeNativeCurrencyPrice.ts
@@ -1,32 +1,8 @@
-import { useCallback, useEffect } from "react";
-import { useTargetNetwork } from "./useTargetNetwork";
-import { useInterval } from "usehooks-ts";
-import scaffoldConfig from "~~/scaffold.config";
-import { useGlobalState } from "~~/services/store/store";
-import { fetchPriceFromUniswap } from "~~/utils/scaffold-eth";
-
-const enablePolling = false;
-
 /**
- * Get the price of Native Currency based on Native Token/DAI trading pair from Uniswap SDK
+ * Disabled: mainnet RPC connection is not needed for this project.
+ * Price fetching via Uniswap requires mainnet access which causes 403 errors
+ * with the default Alchemy API key.
  */
 export const useInitializeNativeCurrencyPrice = () => {
-  const setNativeCurrencyPrice = useGlobalState(state => state.setNativeCurrencyPrice);
-  const setIsNativeCurrencyFetching = useGlobalState(state => state.setIsNativeCurrencyFetching);
-  const { targetNetwork } = useTargetNetwork();
-
-  const fetchPrice = useCallback(async () => {
-    setIsNativeCurrencyFetching(true);
-    const price = await fetchPriceFromUniswap(targetNetwork);
-    setNativeCurrencyPrice(price);
-    setIsNativeCurrencyFetching(false);
-  }, [setIsNativeCurrencyFetching, setNativeCurrencyPrice, targetNetwork]);
-
-  // Get the price of ETH from Uniswap on mount
-  useEffect(() => {
-    fetchPrice();
-  }, [fetchPrice]);
-
-  // Get the price of ETH from Uniswap at a given interval
-  useInterval(fetchPrice, enablePolling ? scaffoldConfig.pollingInterval : null);
+  // noop
 };

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -1,16 +1,13 @@
 import { wagmiConnectors } from "./wagmiConnectors";
 import { Chain, createClient, fallback, http } from "viem";
-import { hardhat, mainnet } from "viem/chains";
+import { hardhat } from "viem/chains";
 import { createConfig } from "wagmi";
 import scaffoldConfig, { DEFAULT_ALCHEMY_API_KEY } from "~~/scaffold.config";
 import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth";
 
 const { targetNetworks } = scaffoldConfig;
 
-// We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-export const enabledChains = targetNetworks.find((network: Chain) => network.id === 1)
-  ? targetNetworks
-  : ([...targetNetworks, mainnet] as const);
+export const enabledChains = targetNetworks;
 
 export const wagmiConfig = createConfig({
   chains: enabledChains,
@@ -22,8 +19,10 @@ export const wagmiConfig = createConfig({
     const alchemyHttpUrl = getAlchemyHttpUrl(chain.id);
     if (alchemyHttpUrl) {
       const isUsingDefaultKey = scaffoldConfig.alchemyApiKey === DEFAULT_ALCHEMY_API_KEY;
-      // If using default Scaffold-ETH 2 API key, we prioritize the default RPC
-      rpcFallbacks = isUsingDefaultKey ? [http(), http(alchemyHttpUrl)] : [http(alchemyHttpUrl), http()];
+      // Skip Alchemy fallback when using the default key (rate-limited/invalid)
+      if (!isUsingDefaultKey) {
+        rpcFallbacks = [http(alchemyHttpUrl), http()];
+      }
     }
 
     return createClient({


### PR DESCRIPTION
## Summary
- wagmi configがmainnetを自動追加してENS解決・ETH価格取得用にRPC接続していたが不要なので削除
- デフォルトのscaffold-eth Alchemy APIキーがrate-limit/無効で403を返すため、デフォルトキー使用時はAlchemy RPCをfallbackに入れないよう変更
- Uniswap価格取得（mainnet RPC必須）を無効化

## Problem
フロントエンドが繰り返し以下にアクセスしてエラーになっていた:
- `eth-mainnet.g.alchemy.com` → 403
- `cloudflare-eth.com` → 200 (Internal Error)
- `eth-sepolia.g.alchemy.com` → 403

## Changes
- `wagmiConfig.tsx`: mainnet自動追加を削除、デフォルトAlchemyキー時はpublic RPCのみ使用
- `useInitializeNativeCurrencyPrice.ts`: mainnet価格取得を無効化（noop）

## Test plan
- [x] フロントエンドが正常に起動すること
- [x] Sepoliaネットワークで正常に動作すること
- [x] コンソールにalchemy/cloudflareへの403エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)